### PR TITLE
Bump SinghDevelopmentKit to 2.1.0

### DIFF
--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -885,7 +885,7 @@
 			repositoryURL = "https://github.com/swiftlysingh/SinghDevelopmentKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
+				minimumVersion = 2.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlysingh/SinghDevelopmentKit.git",
       "state" : {
-        "revision" : "36373cbd1db5e695c57cb27bf03bad8ea01493dd",
-        "version" : "1.2.0"
+        "revision" : "449142a5218e494da22d3c44d77e3555e361e12b",
+        "version" : "2.1.0"
       }
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump the Xcode SPM requirement for SinghDevelopmentKit from 1.2.0 to 2.1.0.
- Update the committed Package.resolved SinghDevelopmentKit pin to 2.1.0 at revision 449142a5218e494da22d3c44d77e3555e361e12b.
- Leave Analytics/Settings source call sites and deployment targets unchanged because no required API or platform bump could be verified from this Linux host.

## Verification
- Confirmed no stale SinghDevelopmentKit 1.2.0 references remain in the workspace.
- Reviewed git diff; only the Xcode package requirement and Package.resolved pin changed.
- Ran `git diff --check` successfully.

## Follow-up required on macOS/Xcode Cloud
- Run `xcodebuild -resolvePackageDependencies -project cards.xcodeproj -scheme cards` to regenerate/confirm Package.resolved, including originHash and transitive pins.
- Build the `cards` and `cards-beta` schemes on supported iOS/macOS destinations.
- Smoke-test analytics startup and the iOS/macOS settings screens.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adf0f95f-77db-4f6d-9d98-ee282a97840f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adf0f95f-77db-4f6d-9d98-ee282a97840f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

