### PR TITLE
Migrate from SinghDevelopmentKit 1.2.0 to SinghDevKit 2.1.1.

### DIFF
--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		EE1D3E982B69379E009733A5 /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1D3E972B69379E009733A5 /* SettingsViewModel.swift */; };
 		EE1D3E9D2B6AC7BC009733A5 /* SharkCardScanViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1D3E9C2B6AC7BC009733A5 /* SharkCardScanViewRepresentable.swift */; };
 		EE3406CE2B6D0FF8007E7DD2 /* SharkCardScan in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = EE3406CD2B6D0FF8007E7DD2 /* SharkCardScan */; };
-		EE4CBEA82CEA98E900635DFC /* OnboardingKit in Frameworks */ = {isa = PBXBuildFile; productRef = EE4CBEA72CEA98E900635DFC /* OnboardingKit */; };
 		EE4CBEAB2CEEC8E900635DFC /* ICloudDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4CBEAA2CEEC8E900635DFC /* ICloudDataManager.swift */; };
 		EE599BAC2B23900A002F49F8 /* AppSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE599BAB2B23900A002F49F8 /* AppSettingsView.swift */; };
 		EE599BAE2B2398DF002F49F8 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE599BAD2B2398DF002F49F8 /* UserSettings.swift */; };
@@ -116,7 +115,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EE4CBEA82CEA98E900635DFC /* OnboardingKit in Frameworks */,
 				EE8ADF0B2F11A0A1C5000002 /* SinghDevKit in Frameworks */,
 				EEABD0D12B6D8AD600FF34E6 /* WhatsNewKit in Frameworks */,
 				EE3406CE2B6D0FF8007E7DD2 /* SharkCardScan in Frameworks */,
@@ -282,7 +280,6 @@
 				EE3406CD2B6D0FF8007E7DD2 /* SharkCardScan */,
 				EEABD0D02B6D8AD600FF34E6 /* WhatsNewKit */,
 				EE8ADF0A2F11A0A1C5000001 /* SinghDevKit */,
-				EE4CBEA72CEA98E900635DFC /* OnboardingKit */,
 			);
 			productName = "credit-card";
 			productReference = EEBB52E62B238D6600035B92 /* Holder.app */;
@@ -341,7 +338,6 @@
 				EE3406CC2B6D0FF8007E7DD2 /* XCRemoteSwiftPackageReference "ios-card-scan" */,
 				EEABD0CF2B6D8AD600FF34E6 /* XCRemoteSwiftPackageReference "WhatsNewKit" */,
 				FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevKit" */,
-				EE4CBEA62CEA98E900635DFC /* XCRemoteSwiftPackageReference "OnboardingKit" */,
 			);
 			productRefGroup = EEBB52E72B238D6600035B92 /* Products */;
 			projectDirPath = "";
@@ -861,14 +857,6 @@
 				kind = branch;
 			};
 		};
-		EE4CBEA62CEA98E900635DFC /* XCRemoteSwiftPackageReference "OnboardingKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/JamesSedlacek/OnboardingKit.git";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		EEABD0CF2B6D8AD600FF34E6 /* XCRemoteSwiftPackageReference "WhatsNewKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SvenTiigi/WhatsNewKit.git";
@@ -892,11 +880,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = EE3406CC2B6D0FF8007E7DD2 /* XCRemoteSwiftPackageReference "ios-card-scan" */;
 			productName = SharkCardScan;
-		};
-		EE4CBEA72CEA98E900635DFC /* OnboardingKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = EE4CBEA62CEA98E900635DFC /* XCRemoteSwiftPackageReference "OnboardingKit" */;
-			productName = OnboardingKit;
 		};
 		EE8ADF0A2F11A0A1C5000001 /* SinghDevKit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -26,7 +26,7 @@
 		EE599BB62B24495F002F49F8 /* CardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE599BB52B24495F002F49F8 /* CardData.swift */; };
 		EE8ADBEF2B66A5B600F0DC29 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8ADBEE2B66A5B600F0DC29 /* HomeViewModel.swift */; };
 		EE8ADF002F1100010000A1C0 /* ArchivedCardsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8ADF012F1100010000A1C1 /* ArchivedCardsView.swift */; };
-		EE8ADF0B2F11A0A1C5000002 /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = EE8ADF0A2F11A0A1C5000001 /* Analytics */; };
+		EE8ADF0B2F11A0A1C5000002 /* SinghDevKit in Frameworks */ = {isa = PBXBuildFile; productRef = EE8ADF0A2F11A0A1C5000001 /* SinghDevKit */; };
 		EE960C4F2B4AC00B00B67805 /* CardDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE960C4E2B4AC00B00B67805 /* CardDataStore.swift */; };
 		EEABD0D12B6D8AD600FF34E6 /* WhatsNewKit in Frameworks */ = {isa = PBXBuildFile; productRef = EEABD0D02B6D8AD600FF34E6 /* WhatsNewKit */; };
 		EEBB52EA2B238D6600035B92 /* CreditCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBB52E92B238D6600035B92 /* CreditCard.swift */; };
@@ -37,7 +37,6 @@
 		EED86E542F0BC2160063097F /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EED86E532F0BC2160063097F /* WidgetKit.framework */; };
 		EED86E562F0BC2170063097F /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EED86E552F0BC2170063097F /* SwiftUI.framework */; };
 		EED86E612F0BC2190063097F /* WidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = EED86E512F0BC2160063097F /* WidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		FF9212C02BE57A50005DF48E /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = FF9212BF2BE57A50005DF48E /* Settings */; };
 		FF9452F92BDE314E00731D8B /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = FF9452F82BDE314E00731D8B /* Secrets.plist */; };
 /* End PBXBuildFile section */
 
@@ -118,8 +117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE4CBEA82CEA98E900635DFC /* OnboardingKit in Frameworks */,
-				FF9212C02BE57A50005DF48E /* Settings in Frameworks */,
-				EE8ADF0B2F11A0A1C5000002 /* Analytics in Frameworks */,
+				EE8ADF0B2F11A0A1C5000002 /* SinghDevKit in Frameworks */,
 				EEABD0D12B6D8AD600FF34E6 /* WhatsNewKit in Frameworks */,
 				EE3406CE2B6D0FF8007E7DD2 /* SharkCardScan in Frameworks */,
 			);
@@ -283,9 +281,8 @@
 			packageProductDependencies = (
 				EE3406CD2B6D0FF8007E7DD2 /* SharkCardScan */,
 				EEABD0D02B6D8AD600FF34E6 /* WhatsNewKit */,
-				FF9212BF2BE57A50005DF48E /* Settings */,
+				EE8ADF0A2F11A0A1C5000001 /* SinghDevKit */,
 				EE4CBEA72CEA98E900635DFC /* OnboardingKit */,
-				EE8ADF0A2F11A0A1C5000001 /* Analytics */,
 			);
 			productName = "credit-card";
 			productReference = EEBB52E62B238D6600035B92 /* Holder.app */;
@@ -343,7 +340,7 @@
 			packageReferences = (
 				EE3406CC2B6D0FF8007E7DD2 /* XCRemoteSwiftPackageReference "ios-card-scan" */,
 				EEABD0CF2B6D8AD600FF34E6 /* XCRemoteSwiftPackageReference "WhatsNewKit" */,
-				FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevelopmentKit" */,
+				FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevKit" */,
 				EE4CBEA62CEA98E900635DFC /* XCRemoteSwiftPackageReference "OnboardingKit" */,
 			);
 			productRefGroup = EEBB52E72B238D6600035B92 /* Products */;
@@ -880,12 +877,12 @@
 				minimumVersion = 2.2.0;
 			};
 		};
-		FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevelopmentKit" */ = {
+		FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/swiftlysingh/SinghDevelopmentKit.git";
+			repositoryURL = "https://github.com/swiftlysingh/SinghDevKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.2.0;
+				minimumVersion = 2.1.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -901,20 +898,15 @@
 			package = EE4CBEA62CEA98E900635DFC /* XCRemoteSwiftPackageReference "OnboardingKit" */;
 			productName = OnboardingKit;
 		};
-		EE8ADF0A2F11A0A1C5000001 /* Analytics */ = {
+		EE8ADF0A2F11A0A1C5000001 /* SinghDevKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevelopmentKit" */;
-			productName = Analytics;
+			package = FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevKit" */;
+			productName = SinghDevKit;
 		};
 		EEABD0D02B6D8AD600FF34E6 /* WhatsNewKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = EEABD0CF2B6D8AD600FF34E6 /* XCRemoteSwiftPackageReference "WhatsNewKit" */;
 			productName = WhatsNewKit;
-		};
-		FF9212BF2BE57A50005DF48E /* Settings */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FF9212BC2BE57A50005DF48E /* XCRemoteSwiftPackageReference "SinghDevelopmentKit" */;
-			productName = Settings;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftlysingh.cards.beta;
 				PRODUCT_NAME = Holder;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
@@ -658,7 +658,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftlysingh.cards.debug;
 				PRODUCT_NAME = Holder;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
@@ -698,7 +698,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.swiftlysingh.cards;
 				PRODUCT_NAME = Holder;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";

--- a/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlysingh/SinghDevKit.git",
       "state" : {
-        "revision" : "f7d77030a7b429262d337b8a43ee6dfd882ffd28",
-        "version" : "2.1.1"
+        "revision" : "5f93576026b04f0a1ae15a13b9ef00b30eec0349",
+        "version" : "2.2.0"
       }
     },
     {

--- a/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "82f9fc5945da3a61eb3a4017ef346dfc0fbbc489f160fe84c532ccdc917d2b68",
+  "originHash" : "d69c62cd0ece5c2cdd02759550ecd9cad8c84039c489a83b6bfa4842e2e5ec10",
   "pins" : [
     {
       "identity" : "ios-card-scan",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "377455779103d45f537ae202b2dbb8575575dc92",
         "version" : "1.0.5"
-      }
-    },
-    {
-      "identity" : "onboardingkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JamesSedlacek/OnboardingKit.git",
-      "state" : {
-        "branch" : "main",
-        "revision" : "e0e0e199a9cb74711308c6037bd6905873eae599"
       }
     },
     {

--- a/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0be06d0359319f812e686af38b91880a54595a556cc20ddd857cd4dbed9d9386",
+  "originHash" : "82f9fc5945da3a61eb3a4017ef346dfc0fbbc489f160fe84c532ccdc917d2b68",
   "pins" : [
     {
       "identity" : "ios-card-scan",
@@ -29,30 +29,30 @@
       }
     },
     {
+      "identity" : "posthog-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PostHog/posthog-ios.git",
+      "state" : {
+        "revision" : "9fcdb83e79b155c0dae104eadf5c269079dcbddb",
+        "version" : "3.62.0"
+      }
+    },
+    {
       "identity" : "purchases-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios.git",
       "state" : {
-        "revision" : "6238361173aa15a02b99de0d6c003b24fa5fa444",
-        "version" : "5.52.1"
+        "revision" : "e89cb027a472e5cf1c15435c4e690b9a3c170cdc",
+        "version" : "5.80.0"
       }
     },
     {
-      "identity" : "singhdevelopmentkit",
+      "identity" : "singhdevkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlysingh/SinghDevelopmentKit.git",
+      "location" : "https://github.com/swiftlysingh/SinghDevKit.git",
       "state" : {
-        "revision" : "36373cbd1db5e695c57cb27bf03bad8ea01493dd",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swiftclient",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/TelemetryDeck/SwiftClient",
-      "state" : {
-        "revision" : "8f332c1c256ba26cc46f74c9e5af94f7b1c37a9c",
-        "version" : "2.11.0"
+        "revision" : "f7d77030a7b429262d337b8a43ee6dfd882ffd28",
+        "version" : "2.1.1"
       }
     },
     {

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -52,7 +52,18 @@ struct CreditCard: App {
 
     /// Shared card data store for menu bar access on macOS
     @State private var cardDataStore = CardDataStore()
-    private let appSecrets = AppSecrets.load()
+    private let sdkBootstrapper: SDKBootstrapper
+
+    init() {
+        let sdkBootstrapper = SDKBootstrapper()
+        let appSecrets = AppSecrets.load()
+
+        self.sdkBootstrapper = sdkBootstrapper
+
+        Task {
+            await sdkBootstrapper.configure(with: appSecrets)
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -63,17 +74,6 @@ struct CreditCard: App {
                         .datastoreLocation(.applicationDefault)
                     ])
                 }
-                .task {
-                    try? await SinghDevKit.shared.configure(
-                        SDKConfiguration(
-                            analytics: .postHog(
-                                projectToken: appSecrets.postHogProjectToken,
-                                host: appSecrets.postHogHost
-                            )
-                        )
-                    )
-                    await SinghDevKit.shared.analytics.trackAppLaunch()
-                }
                 .environment(
                     \.whatsNew,
                      WhatsNewEnvironment(
@@ -81,6 +81,7 @@ struct CreditCard: App {
                         whatsNewCollection: self
                      )
                 )
+                .withSDK(.shared)
                 .showOnboardingIfNeeded(using: .prod)
         }
         #if os(macOS)
@@ -100,6 +101,7 @@ struct CreditCard: App {
     var settingsScene: some Scene {
         SwiftUI.Settings {
             SettingsView(configuration: SettingsViewModel())
+                .withSDK(.shared)
                 .presentationSizing(.fitted)
                 .frame(minWidth: 620, minHeight: 480)
         }
@@ -107,7 +109,46 @@ struct CreditCard: App {
     #endif
 }
 
-private struct AppSecrets {
+private actor SDKBootstrapper {
+    private enum State {
+        case idle
+        case configuring
+        case configured
+        case failed
+    }
+
+    private var state: State = .idle
+
+    func configure(with appSecrets: AppSecrets) async {
+        switch state {
+        case .idle, .failed:
+            state = .configuring
+        case .configuring, .configured:
+            return
+        }
+
+        do {
+            try await SinghDevKit.shared.configure(
+                SDKConfiguration(
+                    analytics: .postHog(
+                        projectToken: appSecrets.postHogProjectToken,
+                        host: appSecrets.postHogHost
+                    )
+                )
+            )
+            await SinghDevKit.shared.analytics.trackAppLaunch()
+            state = .configured
+        } catch {
+            state = .failed
+            assertionFailure("Failed to configure SinghDevKit: \(error.localizedDescription)")
+            #if DEBUG
+            print("[SinghDevKit] Failed to configure: \(error.localizedDescription)")
+            #endif
+        }
+    }
+}
+
+private struct AppSecrets: Sendable {
     let postHogProjectToken: String
     let postHogHost: URL
 

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -5,6 +5,7 @@
 //  Created by Pushpinder Pal Singh on 08/12/23.
 //
 
+import Foundation
 import SwiftUI
 import TipKit
 import WhatsNewKit
@@ -51,15 +52,7 @@ struct CreditCard: App {
 
     /// Shared card data store for menu bar access on macOS
     @State private var cardDataStore = CardDataStore()
-
-    private var appID: String {
-        guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
-              let dict = NSDictionary(contentsOfFile: path) as? [String: AnyObject],
-              let appID = dict["TDeck"] as? String else {
-            fatalError("Missing Secrets.plist or TDeck key - ensure Secrets.plist is added to the project")
-        }
-        return appID
-    }
+    private let appSecrets = AppSecrets.load()
 
     var body: some Scene {
         WindowGroup {
@@ -74,8 +67,8 @@ struct CreditCard: App {
                     try? await SinghDevKit.shared.configure(
                         SDKConfiguration(
                             analytics: .postHog(
-                                projectToken: appID,
-                                host: URL(string: "https://us.i.posthog.com")!
+                                projectToken: appSecrets.postHogProjectToken,
+                                host: appSecrets.postHogHost
                             )
                         )
                     )
@@ -112,6 +105,38 @@ struct CreditCard: App {
         }
     }
     #endif
+}
+
+private struct AppSecrets {
+    let postHogProjectToken: String
+    let postHogHost: URL
+
+    static func load() -> Self {
+        guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
+              let dictionary = NSDictionary(contentsOfFile: path) as? [String: Any] else {
+            fatalError("Missing Secrets.plist - ensure it is added to the project")
+        }
+
+        guard let projectToken = nonEmptyString(from: dictionary["PostHogProjectToken"]) else {
+            fatalError("Missing PostHogProjectToken in Secrets.plist")
+        }
+
+        let host = nonEmptyString(from: dictionary["PostHogHost"])
+            .flatMap(URL.init(string:))
+            ?? URL(string: "https://us.i.posthog.com")!
+
+        return Self(
+            postHogProjectToken: projectToken,
+            postHogHost: host
+        )
+    }
+
+    private static func nonEmptyString(from value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 }
 
 extension OnboardingKit.OnboardingConfiguration {

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import TipKit
 import WhatsNewKit
 import SinghDevKit
-import OnboardingKit
+
 #if os(macOS)
 import AppKit
 #endif
@@ -81,7 +81,19 @@ struct CreditCard: App {
                      )
                 )
                 .withSDK(.shared)
-                .showOnboardingIfNeeded(using: .prod)
+                .showOnboardingIfNeeded(features: [.init(image: Image(systemName: "lock.shield"),
+                                                         title: "Secure Storage",
+                                                         content: "Keep your card details safe with state-of-the-art encryption."),
+                                                   .init(image: Image(systemName: "faceid"),
+                                                         title: "Biometric Authentication",
+                                                         content: "Access your cards securely using Face ID or Touch ID."),
+                                                   .init(image: Image(systemName: "square.and.arrow.up"),
+                                                         title: "Easily Shareable",
+                                                         content: "Quickly and securely share card details with trusted contacts."),
+                                                   .init(image: Image(systemName: "hand.raised.slash"),
+                                                         title: "Privacy First, Open Source",
+                                                         content: "Your data stays private and secure, and the app's code is open-source for transparency.")]
+                )
         }
         #if os(macOS)
         menuBarScene
@@ -139,27 +151,6 @@ private struct AppSecrets: Sendable {
         return trimmed.isEmpty ? nil : trimmed
     }
 }
-
-extension OnboardingKit.OnboardingConfiguration {
-	static let prod = Self.init(privacyUrlString: "",
-								accentColor: .blue,
-								features: [
-									.init(image: Image(systemName: "lock.shield"),
-										  title: "Secure Storage",
-										  content: "Keep your card details safe with state-of-the-art encryption."),
-									.init(image: Image(systemName: "faceid"),
-										  title: "Biometric Authentication",
-										  content: "Access your cards securely using Face ID or Touch ID."),
-									.init(image: Image(systemName: "square.and.arrow.up"),
-										  title: "Easily Shareable",
-										  content: "Quickly and securely share card details with trusted contacts."),
-									.init(image: Image(systemName: "hand.raised.slash"),
-										  title: "Privacy First, Open Source",
-										  content: "Your data stays private and secure, and the app's code is open-source for transparency.")
-								]
-	)
-}
-
 
 extension CreditCard: WhatsNewCollectionProvider {
   var primaryAction: WhatsNew.PrimaryAction {

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -52,18 +52,7 @@ struct CreditCard: App {
 
     /// Shared card data store for menu bar access on macOS
     @State private var cardDataStore = CardDataStore()
-    private let sdkBootstrapper: SDKBootstrapper
-
-    init() {
-        let sdkBootstrapper = SDKBootstrapper()
-        let appSecrets = AppSecrets.load()
-
-        self.sdkBootstrapper = sdkBootstrapper
-
-        Task {
-            await sdkBootstrapper.configure(with: appSecrets)
-        }
-    }
+    private let appSecrets = AppSecrets.load()
 
     var body: some Scene {
         WindowGroup {
@@ -73,6 +62,16 @@ struct CreditCard: App {
                         .displayFrequency(.immediate),
                         .datastoreLocation(.applicationDefault)
                     ])
+
+                    try? await SinghDevKit.shared.configure(
+                        SDKConfiguration(
+                            analytics: .postHog(
+                                projectToken: appSecrets.postHogProjectToken,
+                                host: appSecrets.postHogHost
+                            )
+                        )
+                    )
+                    await SinghDevKit.shared.analytics.trackAppLaunch()
                 }
                 .environment(
                     \.whatsNew,
@@ -107,45 +106,6 @@ struct CreditCard: App {
         }
     }
     #endif
-}
-
-private actor SDKBootstrapper {
-    private enum State {
-        case idle
-        case configuring
-        case configured
-        case failed
-    }
-
-    private var state: State = .idle
-
-    func configure(with appSecrets: AppSecrets) async {
-        switch state {
-        case .idle, .failed:
-            state = .configuring
-        case .configuring, .configured:
-            return
-        }
-
-        do {
-            try await SinghDevKit.shared.configure(
-                SDKConfiguration(
-                    analytics: .postHog(
-                        projectToken: appSecrets.postHogProjectToken,
-                        host: appSecrets.postHogHost
-                    )
-                )
-            )
-            await SinghDevKit.shared.analytics.trackAppLaunch()
-            state = .configured
-        } catch {
-            state = .failed
-            assertionFailure("Failed to configure SinghDevKit: \(error.localizedDescription)")
-            #if DEBUG
-            print("[SinghDevKit] Failed to configure: \(error.localizedDescription)")
-            #endif
-        }
-    }
 }
 
 private struct AppSecrets: Sendable {

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -52,7 +52,16 @@ struct CreditCard: App {
 
     /// Shared card data store for menu bar access on macOS
     @State private var cardDataStore = CardDataStore()
-    private let appSecrets = AppSecrets.load()
+    private let sdkBootstrapper: SDKBootstrapper
+
+    init() {
+        let sdkBootstrapper = SDKBootstrapper()
+        self.sdkBootstrapper = sdkBootstrapper
+
+        Task {
+            await sdkBootstrapper.configure(with: AppSecrets.load())
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -62,16 +71,6 @@ struct CreditCard: App {
                         .displayFrequency(.immediate),
                         .datastoreLocation(.applicationDefault)
                     ])
-
-                    try? await SinghDevKit.shared.configure(
-                        SDKConfiguration(
-                            analytics: .postHog(
-                                projectToken: appSecrets.postHogProjectToken,
-                                host: appSecrets.postHogHost
-                            )
-                        )
-                    )
-                    await SinghDevKit.shared.analytics.trackAppLaunch()
                 }
                 .environment(
                     \.whatsNew,
@@ -120,18 +119,62 @@ struct CreditCard: App {
     #endif
 }
 
+private actor SDKBootstrapper {
+    private enum State {
+        case idle
+        case configuring
+        case configured
+        case failed
+    }
+
+    private var state: State = .idle
+
+    func configure(with appSecrets: AppSecrets?) async {
+        switch state {
+        case .idle, .failed:
+            state = .configuring
+        case .configuring, .configured:
+            return
+        }
+
+        guard let appSecrets else {
+            print("Warning: Missing or invalid Secrets.plist - analytics disabled")
+            state = .failed
+            return
+        }
+
+        do {
+            try await SinghDevKit.shared.configure(
+                SDKConfiguration(
+                    analytics: .postHog(
+                        projectToken: appSecrets.postHogProjectToken,
+                        host: appSecrets.postHogHost
+                    )
+                )
+            )
+            await SinghDevKit.shared.analytics.trackAppLaunch()
+            state = .configured
+        } catch {
+            state = .failed
+            print("Warning: Failed to configure SinghDevKit: \(error.localizedDescription)")
+        }
+    }
+}
+
 private struct AppSecrets: Sendable {
     let postHogProjectToken: String
     let postHogHost: URL
 
-    static func load() -> Self {
+    static func load() -> Self? {
         guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
               let dictionary = NSDictionary(contentsOfFile: path) as? [String: Any] else {
-            fatalError("Missing Secrets.plist - ensure it is added to the project")
+            print("Warning: Missing Secrets.plist - analytics disabled")
+            return nil
         }
 
         guard let projectToken = nonEmptyString(from: dictionary["PostHogProjectToken"]) else {
-            fatalError("Missing PostHogProjectToken in Secrets.plist")
+            print("Warning: Missing PostHogProjectToken in Secrets.plist - analytics disabled")
+            return nil
         }
 
         let host = nonEmptyString(from: dictionary["PostHogHost"])

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -8,9 +8,8 @@
 import SwiftUI
 import TipKit
 import WhatsNewKit
-import Analytics
+import SinghDevKit
 import OnboardingKit
-import Settings
 #if os(macOS)
 import AppKit
 #endif
@@ -72,8 +71,15 @@ struct CreditCard: App {
                     ])
                 }
                 .task {
-                    await AnalyticsManager.shared.configure(with: appID)
-                    await AnalyticsManager.shared.appDidFinishLaunching()
+                    try? await SinghDevKit.shared.configure(
+                        SDKConfiguration(
+                            analytics: .postHog(
+                                projectToken: appID,
+                                host: URL(string: "https://us.i.posthog.com")!
+                            )
+                        )
+                    )
+                    await SinghDevKit.shared.analytics.trackAppLaunch()
                 }
                 .environment(
                     \.whatsNew,
@@ -100,7 +106,7 @@ struct CreditCard: App {
 
     var settingsScene: some Scene {
         SwiftUI.Settings {
-            SettingsView(model: SettingsViewModel())
+            SettingsView(configuration: SettingsViewModel())
                 .presentationSizing(.fitted)
                 .frame(minWidth: 620, minHeight: 480)
         }
@@ -108,7 +114,7 @@ struct CreditCard: App {
     #endif
 }
 
-extension OnboardingConfiguration {
+extension OnboardingKit.OnboardingConfiguration {
 	static let prod = Self.init(privacyUrlString: "",
 								accentColor: .blue,
 								features: [

--- a/cards/Home/HomeView.swift
+++ b/cards/Home/HomeView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 import WhatsNewKit
-import Settings
+import SinghDevKit
 
 struct HomeView: View {
 	@ObservedObject var model: HomeViewModel
@@ -76,7 +76,7 @@ struct HomeView: View {
 			}
 			#if !os(macOS)
 			.toolbar {
-				NavigationLink(destination: SettingsView(model: SettingsViewModel())) {
+				NavigationLink(destination: SettingsView(configuration: SettingsViewModel())) {
 					Image(systemName: "gear")
 				}
 			}

--- a/cards/Settings/SettingsViewModel.swift
+++ b/cards/Settings/SettingsViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Pushpinder Pal Singh on 30/01/24.
 //
 
-import Settings
+import SinghDevKit
 import SwiftUI
 
 #if os(iOS)
@@ -17,13 +17,15 @@ struct SettingsViewModel: SettingsViewModelProtocol {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     }
 
-    var privacyPolicy: String {
-        "https://docs.google.com/document/d/1OD3foirDwAsmZ8Mp6cYJlDpUjAyDpvgX7rvzosnNQes"
+    var privacyPolicyURL: URL? {
+        URL(string: "https://docs.google.com/document/d/1OD3foirDwAsmZ8Mp6cYJlDpUjAyDpvgX7rvzosnNQes")
     }
 
-    var sourceCode: String? {
-        "https://github.com/swiftlysingh/holder/"
+    var sourceCodeURL: URL? {
+        URL(string: "https://github.com/swiftlysingh/holder/")
     }
+
+    var showsSubscriptionManagement: Bool { false }
 
     var linesOfCode: Int {
         2200

--- a/cards/Settings/SettingsViewModel.swift
+++ b/cards/Settings/SettingsViewModel.swift
@@ -27,10 +27,6 @@ struct SettingsViewModel: SettingsViewModelProtocol {
 
     var showsSubscriptionManagement: Bool { false }
 
-    var linesOfCode: Int {
-        2200
-    }
-
     @ViewBuilder var appSettings: some View {
         AppSettingsView()
     }

--- a/cards/Settings/SettingsViewModel.swift
+++ b/cards/Settings/SettingsViewModel.swift
@@ -30,8 +30,6 @@ struct SettingsViewModel: SettingsViewModelProtocol {
     @ViewBuilder var appSettings: some View {
         AppSettingsView()
     }
-
-    func rateTheAppAction() {
-        ReviewService.requestReview()
-    }
+    
+    var appReview: AppReviewConfiguration = .appStoreID("6475649492")
 }


### PR DESCRIPTION
Switch the renamed package, consolidate Analytics and Settings into the unified SinghDevKit product, and update app call sites for the new SDK configuration and settings APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated app launch tracking to use the latest shared kit, with PostHog configuration loaded from `Secrets.plist`.
  * Onboarding is now configured with explicitly listed feature cards.
  * Settings now exposes privacy policy and source code as direct URL links, plus a non-functional subscription management toggle placeholder.
* **Bug Fixes**
  * Improved Settings UI wiring from the home toolbar across platforms, including macOS.
* **Chores**
  * Refreshed Swift package dependencies and updated the SwiftPM lockfile to match the new shared kit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->