### PR TITLE
Fix archived cards resetting after reload

### DIFF
--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -40,6 +40,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		CD29000B2F2100010000000B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EEBB52DE2B238D6600035B92 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EEBB52E52B238D6600035B92;
+			remoteInfo = cards;
+		};
 		EED86E5F2F0BC2190063097F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = EEBB52DE2B238D6600035B92 /* Project object */;
@@ -64,6 +71,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CD2900012F21000100000001 /* cardsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cardsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA0000012F0BC0000000001A /* PlatformTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTypes.swift; sourceTree = "<group>"; };
 		AA0000022F0BC0000000001B /* PasteboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardService.swift; sourceTree = "<group>"; };
 		AA0000032F0BC0000000001C /* HapticService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticService.swift; sourceTree = "<group>"; };
@@ -107,10 +115,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		CD2900022F21000100000002 /* cardsTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = cardsTests; sourceTree = "<group>"; };
 		EED86E572F0BC2170063097F /* Widgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (EED86E662F0BC2190063097F /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Widgets; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		CD2900052F21000100000005 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEBB52E32B238D6600035B92 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -195,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				EEBB52E82B238D6600035B92 /* cards */,
+				CD2900022F21000100000002 /* cardsTests */,
 				EED86E572F0BC2170063097F /* Widgets */,
 				EED86E522F0BC2160063097F /* Frameworks */,
 				EEBB52E72B238D6600035B92 /* Products */,
@@ -206,6 +223,7 @@
 			children = (
 				EEBB52E62B238D6600035B92 /* Holder.app */,
 				EED86E512F0BC2160063097F /* WidgetsExtension.appex */,
+				CD2900012F21000100000001 /* cardsTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -261,6 +279,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		CD2900032F21000100000003 /* cardsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CD2900072F21000100000007 /* Build configuration list for PBXNativeTarget "cardsTests" */;
+			buildPhases = (
+				CD2900042F21000100000004 /* Sources */,
+				CD2900052F21000100000005 /* Frameworks */,
+				CD2900062F21000100000006 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CD29000C2F2100010000000C /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				CD2900022F21000100000002 /* cardsTests */,
+			);
+			name = cardsTests;
+			packageProductDependencies = (
+			);
+			productName = cardsTests;
+			productReference = CD2900012F21000100000001 /* cardsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		EEBB52E52B238D6600035B92 /* cards */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EEBB52F42B238D6800035B92 /* Build configuration list for PBXNativeTarget "cards" */;
@@ -317,6 +358,10 @@
 				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
+					CD2900032F21000100000003 = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = EEBB52E52B238D6600035B92;
+					};
 					EEBB52E52B238D6600035B92 = {
 						CreatedOnToolsVersion = 15.0;
 					};
@@ -345,11 +390,19 @@
 			targets = (
 				EEBB52E52B238D6600035B92 /* cards */,
 				EED86E502F0BC2160063097F /* WidgetsExtension */,
+				CD2900032F21000100000003 /* cardsTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		CD2900062F21000100000006 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEBB52E42B238D6600035B92 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -370,6 +423,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		CD2900042F21000100000004 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEBB52E22B238D6600035B92 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -408,6 +468,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		CD29000C2F2100010000000C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EEBB52E52B238D6600035B92 /* cards */;
+			targetProxy = CD29000B2F2100010000000B /* PBXContainerItemProxy */;
+		};
 		EED86E602F0BC2190063097F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = EED86E502F0BC2160063097F /* WidgetsExtension */;
@@ -416,6 +481,84 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		CD2900082F21000100000008 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4WMQY24R33;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftlysingh.cardsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Holder.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Holder";
+			};
+			name = Debug;
+		};
+		CD2900092F21000100000009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4WMQY24R33;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftlysingh.cardsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Holder.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Holder";
+			};
+			name = Release;
+		};
+		CD29000A2F2100010000000A /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4WMQY24R33;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swiftlysingh.cardsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Holder.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Holder";
+			};
+			name = Beta;
+		};
 		EE1D3E952B692C9F009733A5 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -816,6 +959,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		CD2900072F21000100000007 /* Build configuration list for PBXNativeTarget "cardsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD2900082F21000100000008 /* Debug */,
+				CD2900092F21000100000009 /* Release */,
+				CD29000A2F2100010000000A /* Beta */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		EEBB52E12B238D6600035B92 /* Build configuration list for PBXProject "cards" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/cards.xcodeproj/xcshareddata/xcschemes/cards.xcscheme
+++ b/cards.xcodeproj/xcshareddata/xcschemes/cards.xcscheme
@@ -28,6 +28,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CD2900032F21000100000003"
+               BuildableName = "cardsTests.xctest"
+               BlueprintName = "cardsTests"
+               ReferencedContainer = "container:cards.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/cards/Model/CardData.swift
+++ b/cards/Model/CardData.swift
@@ -18,6 +18,10 @@ struct CardData : Identifiable, Codable, Hashable {
 	var network: CardNetwork
 	var isArchived: Bool
 
+	private enum CodingKeys: String, CodingKey {
+		case id, number, cvv, expiration, name, description, type, network, isArchived
+	}
+
 	init(
 		id: UUID,
 		number: String,
@@ -59,6 +63,24 @@ struct CardData : Identifiable, Codable, Hashable {
 		self.network = network
 		self.isArchived = isArchived
 	}
+
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		let number = try container.decode(String.self, forKey: .number)
+
+		self.init(
+			id: try container.decode(UUID.self, forKey: .id),
+			number: number,
+			cvv: try container.decode(String.self, forKey: .cvv),
+			expiration: try container.decode(String.self, forKey: .expiration),
+			name: try container.decode(String.self, forKey: .name),
+			description: try container.decode(String.self, forKey: .description),
+			type: try container.decode(CardType.self, forKey: .type),
+			network: try container.decodeIfPresent(CardNetwork.self, forKey: .network) ?? number.getCardNetwork(),
+			isArchived: try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+		)
+	}
+
 	func toShareString() -> String {
 		return "Name: \(self.name) \nNumber: \(number) \nExpiration: \(expiration) \nSecurity Code: \(cvv)"
 	}
@@ -102,29 +124,5 @@ extension CardData {
 	func toData() throws -> Data {
 		let encoder = JSONEncoder()
 		return try encoder.encode(self)
-	}
-}
-
-struct OldCardData : Identifiable, Codable, Hashable {
-	var id: UUID
-	var number : String
-	var cvv : String
-	var expiration : String
-	var name : String
-	var description: String
-	var type : CardType
-
-	func transferToNewSchema() -> CardData {
-		return CardData(
-			id: id,
-			number: number,
-			cvv: cvv,
-			expiration: expiration,
-			name: name,
-			description: description,
-			type: type,
-			network: number.getCardNetwork(),
-			isArchived: false
-		)
 	}
 }

--- a/cards/Model/CardDataStore.swift
+++ b/cards/Model/CardDataStore.swift
@@ -35,7 +35,6 @@ class CardDataStore {
 	}
 
 	func loadCards() {
-		migrateToNewSchema(for: Bundle.main.bundleIdentifier ?? "com.myApp.defaultService")
 		var retrievedCard = retrieveAllCardData(service: Bundle.main.bundleIdentifier ?? "com.myApp.defaultService") ?? []
 
 			//		Add default data for simulator
@@ -70,14 +69,18 @@ class CardDataStore {
 			)
 
 		}
-		// Separate archived and active cards
-		archivedCards = retrievedCard.filter { $0.isArchived }
-		let activeCards = retrievedCard.filter { !$0.isArchived }
-
-		for type in CardType.allCases {
-			cardsByType[type] = activeCards.filter { $0.type == type }
-		}
+		let partition = Self.partition(retrievedCard)
+		cardsByType = partition.cardsByType
+		archivedCards = partition.archivedCards
 		syncCardsToWidget()
+	}
+
+	static func partition(_ cards: [CardData]) -> (cardsByType: [CardType: [CardData]], archivedCards: [CardData]) {
+		let activeCards = cards.filter { !$0.isArchived }
+		let cardsByType = Dictionary(uniqueKeysWithValues: CardType.allCases.map { type in
+			(type, activeCards.filter { $0.type == type })
+		})
+		return (cardsByType, cards.filter { $0.isArchived })
 	}
 
 	func addCard(_ card: CardData) {
@@ -114,32 +117,21 @@ class CardDataStore {
 	func archiveCard(_ card: CardData) {
 		var archivedCard = card
 		archivedCard.isArchived = true
-		_ = saveOrUpdateCardData(archivedCard)
-
-		// Remove from active cards
-		if let index = cardsByType[card.type]?.firstIndex(where: { $0.id == card.id }) {
-			cardsByType[card.type]?.remove(at: index)
+		guard saveOrUpdateCardData(archivedCard) else {
+			print("Failed to archive card: \(card.id)")
+			return
 		}
-		// Add to archived list
-		archivedCards.append(archivedCard)
-		syncCardsToWidget()
+		loadCards()
 	}
 
 	func unarchiveCard(_ card: CardData) {
 		var unarchivedCard = card
 		unarchivedCard.isArchived = false
-		_ = saveOrUpdateCardData(unarchivedCard)
-
-		// Remove from archived cards
-		if let index = archivedCards.firstIndex(where: { $0.id == card.id }) {
-			archivedCards.remove(at: index)
+		guard saveOrUpdateCardData(unarchivedCard) else {
+			print("Failed to unarchive card: \(card.id)")
+			return
 		}
-		// Add back to active cards
-		if cardsByType[card.type] == nil {
-			cardsByType[card.type] = []
-		}
-		cardsByType[card.type]?.append(unarchivedCard)
-		syncCardsToWidget()
+		loadCards()
 	}
 /// Returns if success
 	private func saveOrUpdateCardData(_ cardData: CardData) -> Bool {
@@ -243,40 +235,4 @@ class CardDataStore {
 		WidgetCenter.shared.reloadAllTimelines()
 	}
 
-	private func migrateToNewSchema(for service: String) {
-		let query: [String: Any] = [
-			kSecClass as String: kSecClassGenericPassword,
-			kSecAttrService as String: service,
-			kSecMatchLimit as String: kSecMatchLimitAll,
-			kSecReturnAttributes as String: kCFBooleanTrue!,
-			kSecReturnData as String: kCFBooleanTrue!,
-			kSecAttrSynchronizable as String: kCFBooleanTrue!
-		]
-
-		var items: CFTypeRef?
-		let status = SecItemCopyMatching(query as CFDictionary, &items)
-
-		guard status == errSecSuccess else {
-			print("Error retrieving old from Keychain: \(status)")
-			return
-		}
-
-		guard let existingItems = items as? [[String: Any]] else {
-			print("No items found in the Keychain")
-			return
-		}
-
-		for item in existingItems {
-
-			if let data = item[kSecValueData as String] as? Data {
-				do {
-					let oldCardData = try JSONDecoder().decode(OldCardData.self, from: data)
-					_ = saveOrUpdateCardData(oldCardData.transferToNewSchema())
-				} catch {
-					print("Error decoding CardData: \(error)")
-						// Optionally handle the error, e.g., continue with next item
-				}
-			}
-		}
-	}
 }

--- a/cardsTests/CardDataPersistenceTests.swift
+++ b/cardsTests/CardDataPersistenceTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Holder
+
+final class CardDataPersistenceTests: XCTestCase {
+	func testArchivedCardRoundTripPreservesState() throws {
+		var card = makeCard(id: UUID(), isArchived: true)
+		card.network = .master
+
+		let data = try JSONEncoder().encode(card)
+		let decoded = try JSONDecoder().decode(CardData.self, from: data)
+
+		XCTAssertTrue(decoded.isArchived)
+		XCTAssertEqual(decoded.network, .master)
+	}
+
+	func testLegacyCardDefaultsToActiveAndDerivesNetwork() throws {
+		let id = UUID()
+		let data = try JSONSerialization.data(withJSONObject: [
+			"id": id.uuidString,
+			"number": "4111111111111111",
+			"cvv": "123",
+			"expiration": "12/30",
+			"name": "Legacy Card",
+			"description": "",
+			"type": CardType.creditCard.rawValue
+		])
+
+		let card = try JSONDecoder().decode(CardData.self, from: data)
+
+		XCTAssertEqual(card.id, id)
+		XCTAssertEqual(card.network, .visa)
+		XCTAssertFalse(card.isArchived)
+	}
+
+	func testPartitionSeparatesActiveAndArchivedCards() {
+		let creditCard = makeCard(id: UUID())
+		let debitCard = makeCard(id: UUID(), type: .debitCard)
+		let archivedCard = makeCard(id: UUID(), type: .otherCard, isArchived: true)
+
+		let partition = CardDataStore.partition([creditCard, debitCard, archivedCard])
+		let activeCards = CardType.allCases.flatMap { partition.cardsByType[$0] ?? [] }
+
+		XCTAssertEqual(activeCards.count, 2)
+		XCTAssertEqual(Set(activeCards.map(\.id)), [creditCard.id, debitCard.id])
+		XCTAssertEqual(partition.archivedCards.map(\.id), [archivedCard.id])
+	}
+
+	private func makeCard(
+		id: UUID,
+		type: CardType = .creditCard,
+		isArchived: Bool = false
+	) -> CardData {
+		CardData(
+			id: id,
+			number: "4111111111111111",
+			cvv: "123",
+			expiration: "12/30",
+			name: "Test Card",
+			description: "",
+			type: type,
+			network: .visa,
+			isArchived: isArchived
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- decode legacy card payloads with safe defaults in `CardData`
- remove the destructive load-time migration that reset `isArchived`
- persist archive changes before updating in-memory collections
- rebuild active and archived collections through one partition path
- add a hosted XCTest target with focused Codable and partition coverage

## Root cause

`CardDataStore.loadCards()` ran the legacy migration on every load. Swift `Codable` ignored the newer fields when decoding current records as `OldCardData`, so the migration rewrote valid records with `isArchived = false`.

## User impact

Archived cards remain archived after reload or relaunch. If a Keychain write fails, the card now stays in its current UI collection instead of showing a state that was not persisted.

Fixes #29.

## Validation

- `xcodebuild test -project cards.xcodeproj -scheme cards -destination 'platform=macOS' -derivedDataPath /tmp/holder-review-tests CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -quiet -project cards.xcodeproj -scheme cards -destination 'generic/platform=iOS' -derivedDataPath /tmp/holder-review-ios CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
- project, scheme, and JSON syntax checks

All three tests pass. The generic iOS build succeeds with the existing app/widget `CFBundleShortVersionString` mismatch warning.

## Test coverage note

The archive round-trip test exercises `Codable`; it does not write and reload through Keychain. A full Keychain integration test would require introducing an isolated persistence service, so that broader test seam is intentionally left out of this focused fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added support for decoding and restoring card data from JSON, including archived status and card network details.
- Improved card organization by separating active cards from archived cards.

## Bug Fixes
- Restored cards now persist correctly and refresh across the app after being unarchived.

## Tests
- Added automated coverage for card persistence, legacy data decoding, network detection, and active/archived card separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->