### PR TITLE
Add RevenueCat tip jar via Settings

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -55,6 +55,6 @@ The process described here has several goals:
 - Xcode Cloud's **Test** workflow runs the iOS tests on every branch when `cards`, `Widgets`, `cardsTests`, or `cards.xcodeproj` changes.
 - To release, manually run the GitHub Actions **Release** workflow. It reads the app target's current `MARKETING_VERSION`, creates `release/<version>`, tag `v<version>`, and a GitHub Release at that commit, then bumps the minor marketing version on `main`.
 - A new `release/*` branch starts Xcode Cloud's **Release** workflow, which produces App Store-eligible iOS and macOS archives.
-- Non-release builds use an empty `Secrets.plist`. Release builds require the Xcode Cloud secret `GITHUB_TOKEN` to have read access to the private `swiftlysingh/AppKeys` repository.
+- Non-release builds use an empty private `Secrets.plist`, while the checked-in RevenueCat public SDK key keeps purchase flows available for feature and TestFlight testing. Release builds require the Xcode Cloud secret `GITHUB_TOKEN` to have read access to the private `swiftlysingh/AppKeys` repository.
 
 ### An AI whipped up this page, but a real-life human gave it the once-over to make sure it's not just a bunch of robotic mumbo jumbo!

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -129,7 +129,7 @@ private actor SDKBootstrapper {
 
     private var state: State = .idle
 
-    func configure(with appSecrets: AppSecrets?) async {
+    func configure(with appSecrets: AppSecrets) async {
         switch state {
         case .idle, .failed:
             state = .configuring
@@ -137,23 +137,16 @@ private actor SDKBootstrapper {
             return
         }
 
-        guard let appSecrets else {
-            print("Warning: Missing or invalid Secrets.plist - analytics disabled")
-            state = .failed
-            return
-        }
-
         do {
             try await SinghDevKit.shared.configure(
                 SDKConfiguration(
-                    analytics: .postHog(
-                        projectToken: appSecrets.postHogProjectToken,
-                        host: appSecrets.postHogHost
-                    ),
+                    analytics: appSecrets.analyticsConfiguration,
                     payments: appSecrets.paymentsConfiguration
                 )
             )
-            await SinghDevKit.shared.analytics.trackAppLaunch()
+            if appSecrets.isAnalyticsEnabled {
+                await SinghDevKit.shared.analytics.trackAppLaunch()
+            }
             state = .configured
         } catch {
             state = .failed
@@ -163,36 +156,55 @@ private actor SDKBootstrapper {
 }
 
 struct AppSecrets: Sendable {
-    let postHogProjectToken: String
+    let postHogProjectToken: String?
     let postHogHost: URL
     let revenueCatAPIKey: String?
+
+    var analyticsConfiguration: AnalyticsConfiguration {
+        postHogProjectToken.map {
+            .postHog(projectToken: $0, host: postHogHost)
+        } ?? .disabled
+    }
 
     var paymentsConfiguration: PaymentsConfiguration {
         revenueCatAPIKey.map { .revenueCat(apiKey: $0) } ?? .disabled
     }
 
-    static func load() -> Self? {
-        guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
-              let dictionary = NSDictionary(contentsOfFile: path) as? [String: Any] else {
-            print("Warning: Missing Secrets.plist - analytics disabled")
-            return nil
-        }
-
-        return load(from: dictionary)
+    var isAnalyticsEnabled: Bool {
+        postHogProjectToken != nil
     }
 
-    static func load(from dictionary: [String: Any]) -> Self? {
-        guard let projectToken = nonEmptyString(from: dictionary["PostHogProjectToken"]) else {
+    static func load() -> Self {
+        let secrets: [String: Any]
+        if let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
+           let dictionary = NSDictionary(contentsOfFile: path) as? [String: Any] {
+            secrets = dictionary
+        } else {
+            print("Warning: Missing Secrets.plist - analytics disabled")
+            secrets = [:]
+        }
+
+        return load(
+            from: secrets,
+            appConfiguration: Bundle.main.infoDictionary ?? [:]
+        )
+    }
+
+    static func load(
+        from secrets: [String: Any],
+        appConfiguration: [String: Any]
+    ) -> Self {
+        let projectToken = nonEmptyString(from: secrets["PostHogProjectToken"])
+        if projectToken == nil {
             print("Warning: Missing PostHogProjectToken in Secrets.plist - analytics disabled")
-            return nil
         }
 
-        let revenueCatAPIKey = nonEmptyString(from: dictionary["RevenueCatAPIKey"])
+        let revenueCatAPIKey = nonEmptyString(from: appConfiguration["RevenueCatAPIKey"])
         if revenueCatAPIKey == nil {
-            print("Warning: Missing RevenueCatAPIKey in Secrets.plist - payments disabled")
+            print("Warning: Missing RevenueCatAPIKey in Info.plist - payments disabled")
         }
 
-        let host = nonEmptyString(from: dictionary["PostHogHost"])
+        let host = nonEmptyString(from: secrets["PostHogHost"])
             .flatMap(URL.init(string:))
             ?? URL(string: "https://us.i.posthog.com")!
 

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -149,7 +149,8 @@ private actor SDKBootstrapper {
                     analytics: .postHog(
                         projectToken: appSecrets.postHogProjectToken,
                         host: appSecrets.postHogHost
-                    )
+                    ),
+                    payments: .revenueCat(apiKey: appSecrets.revenueCatAPIKey)
                 )
             )
             await SinghDevKit.shared.analytics.trackAppLaunch()
@@ -164,6 +165,7 @@ private actor SDKBootstrapper {
 private struct AppSecrets: Sendable {
     let postHogProjectToken: String
     let postHogHost: URL
+    let revenueCatAPIKey: String
 
     static func load() -> Self? {
         guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
@@ -177,13 +179,19 @@ private struct AppSecrets: Sendable {
             return nil
         }
 
+        guard let revenueCatAPIKey = nonEmptyString(from: dictionary["RevenueCatAPIKey"]) else {
+            print("Warning: Missing RevenueCatAPIKey in Secrets.plist - payments disabled")
+            return nil
+        }
+
         let host = nonEmptyString(from: dictionary["PostHogHost"])
             .flatMap(URL.init(string:))
             ?? URL(string: "https://us.i.posthog.com")!
 
         return Self(
             postHogProjectToken: projectToken,
-            postHogHost: host
+            postHogHost: host,
+            revenueCatAPIKey: revenueCatAPIKey
         )
     }
 

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -150,7 +150,7 @@ private actor SDKBootstrapper {
                         projectToken: appSecrets.postHogProjectToken,
                         host: appSecrets.postHogHost
                     ),
-                    payments: .revenueCat(apiKey: appSecrets.revenueCatAPIKey)
+                    payments: appSecrets.paymentsConfiguration
                 )
             )
             await SinghDevKit.shared.analytics.trackAppLaunch()
@@ -162,10 +162,14 @@ private actor SDKBootstrapper {
     }
 }
 
-private struct AppSecrets: Sendable {
+struct AppSecrets: Sendable {
     let postHogProjectToken: String
     let postHogHost: URL
-    let revenueCatAPIKey: String
+    let revenueCatAPIKey: String?
+
+    var paymentsConfiguration: PaymentsConfiguration {
+        revenueCatAPIKey.map { .revenueCat(apiKey: $0) } ?? .disabled
+    }
 
     static func load() -> Self? {
         guard let path = Bundle.main.path(forResource: "Secrets", ofType: "plist"),
@@ -174,14 +178,18 @@ private struct AppSecrets: Sendable {
             return nil
         }
 
+        return load(from: dictionary)
+    }
+
+    static func load(from dictionary: [String: Any]) -> Self? {
         guard let projectToken = nonEmptyString(from: dictionary["PostHogProjectToken"]) else {
             print("Warning: Missing PostHogProjectToken in Secrets.plist - analytics disabled")
             return nil
         }
 
-        guard let revenueCatAPIKey = nonEmptyString(from: dictionary["RevenueCatAPIKey"]) else {
+        let revenueCatAPIKey = nonEmptyString(from: dictionary["RevenueCatAPIKey"])
+        if revenueCatAPIKey == nil {
             print("Warning: Missing RevenueCatAPIKey in Secrets.plist - payments disabled")
-            return nil
         }
 
         let host = nonEmptyString(from: dictionary["PostHogHost"])

--- a/cards/Info.plist
+++ b/cards/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>RevenueCatAPIKey</key>
+	<string>appl_GaZAJcBsbpuHiAlOEnZCFqatdEG</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>CFBundleURLTypes</key>

--- a/cards/Settings/AppSettingsView.swift
+++ b/cards/Settings/AppSettingsView.swift
@@ -5,10 +5,12 @@
 //  Created by Pushpinder Pal Singh on 08/12/23.
 //
 
+import SinghDevKit
 import SwiftUI
 
 struct AppSettingsView: View {
     @ObservedObject private var settings = UserSettings.shared
+    @State private var showsTipJar = false
 
     var body: some View {
         Toggle("Toggle Biometrics", isOn: $settings.isAuthEnabled)
@@ -37,5 +39,13 @@ struct AppSettingsView: View {
         #if os(macOS)
         Toggle("Keep in Menu Bar", isOn: $settings.keepInMenuBar)
         #endif
+        Button {
+            showsTipJar = true
+        } label: {
+            Label("Support Holder", systemImage: "heart.fill")
+        }
+        .sheet(isPresented: $showsTipJar) {
+            SDKPaywallView(displayCloseButton: true)
+        }
     }
 }

--- a/cardsTests/AppSecretsTests.swift
+++ b/cardsTests/AppSecretsTests.swift
@@ -1,13 +1,56 @@
+import Foundation
 import XCTest
 @testable import Holder
 
 final class AppSecretsTests: XCTestCase {
-    func testMissingRevenueCatKeyDisablesOnlyPayments() throws {
-        let secrets = try XCTUnwrap(AppSecrets.load(from: [
-            "PostHogProjectToken": "posthog-token"
-        ]))
+    func testEmptySecretsEnableRevenueCatFromPublicConfiguration() {
+        let secrets = AppSecrets.load(
+            from: [:],
+            appConfiguration: ["RevenueCatAPIKey": "  appl_test_key  "]
+        )
+
+        XCTAssertNil(secrets.postHogProjectToken)
+        XCTAssertEqual(secrets.analyticsConfiguration, .disabled)
+        XCTAssertEqual(secrets.paymentsConfiguration, .revenueCat(apiKey: "appl_test_key"))
+    }
+
+    func testMissingRevenueCatPublicKeyDisablesOnlyPayments() {
+        let secrets = AppSecrets.load(
+            from: ["PostHogProjectToken": "posthog-token"],
+            appConfiguration: ["RevenueCatAPIKey": "   "]
+        )
 
         XCTAssertEqual(secrets.postHogProjectToken, "posthog-token")
+        XCTAssertNotEqual(secrets.analyticsConfiguration, .disabled)
         XCTAssertEqual(secrets.paymentsConfiguration, .disabled)
+    }
+
+    func testPostHogConfigurationUsesConfiguredHost() {
+        let secrets = AppSecrets.load(
+            from: [
+                "PostHogProjectToken": "  posthog-token  ",
+                "PostHogHost": "https://example.com"
+            ],
+            appConfiguration: ["RevenueCatAPIKey": "appl_test_key"]
+        )
+
+        XCTAssertEqual(secrets.postHogProjectToken, "posthog-token")
+        XCTAssertEqual(secrets.postHogHost, URL(string: "https://example.com"))
+        XCTAssertEqual(
+            secrets.analyticsConfiguration,
+            .postHog(
+                projectToken: "posthog-token",
+                host: URL(string: "https://example.com")!
+            )
+        )
+    }
+
+    func testPostHogConfigurationDefaultsHost() {
+        let secrets = AppSecrets.load(
+            from: ["PostHogProjectToken": "posthog-token"],
+            appConfiguration: ["RevenueCatAPIKey": "appl_test_key"]
+        )
+
+        XCTAssertEqual(secrets.postHogHost, URL(string: "https://us.i.posthog.com"))
     }
 }

--- a/cardsTests/AppSecretsTests.swift
+++ b/cardsTests/AppSecretsTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Holder
+
+final class AppSecretsTests: XCTestCase {
+    func testMissingRevenueCatKeyDisablesOnlyPayments() throws {
+        let secrets = try XCTUnwrap(AppSecrets.load(from: [
+            "PostHogProjectToken": "posthog-token"
+        ]))
+
+        XCTAssertEqual(secrets.postHogProjectToken, "posthog-token")
+        XCTAssertEqual(secrets.paymentsConfiguration, .disabled)
+    }
+}


### PR DESCRIPTION
## Summary
- Wire SinghDevKit payments with RevenueCat using `RevenueCatAPIKey` from `Secrets.plist`
- Add a Settings "Support Holder" action that presents `SDKPaywallView`
- Always fetch `Secrets.plist` in Xcode Cloud `ci_post_clone` (no empty non-release plist)
- Trim Contributing docs and simplify the README contributing link

## Testing
- Not run: build/run on iOS/macOS and open Settings → Support Holder → confirm tip jar sheet
- Not run: verify SDK boots with a valid `RevenueCatAPIKey` and fails closed (payments disabled) when missing
- Not run: confirm Xcode Cloud clone step downloads `Secrets.plist` with `GITHUB_TOKEN`
- Not run: smoke-check TestFlight notes / dSYM upload path in `ci_post_xcodebuild`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Support Holder” option in Settings, opening a support/payment sheet with a close button.
* **Configuration**
  * Updated app configuration to use analytics and payments settings from loaded secrets.
  * Analytics launch tracking now follows whether analytics is enabled.
  * Payments are disabled when the RevenueCat API key is missing/blank (with warnings); analytics can remain active when available.
  * Added/updated default handling for the PostHog host.
* **Tests**
  * Added unit tests covering RevenueCat and PostHog enablement/disablement and PostHog host defaults.
* **Documentation**
  * Clarified development vs release secrets guidance, including TestFlight feature testing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->