### PR TITLE
Finish SinghDevKit analytics integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+## SinghDevKit
+
+- Import and configure SinghDevKit once; do not initialize PostHog or RevenueCat directly.
+- Keep SDK-powered views below `.withSDK(sdk)`.
+- Use SDK Settings (`sdk.settingsView()` / `SDKSettingsView`) as the app's Settings destination and preserve app-specific controls through `SettingsViewModelProtocol`.
+- Use SinghDevKit for onboarding, payments, entitlement checks, paywalls, Customer Center, analytics transport, and SDK-owned events when those capabilities apply.
+- Define product events as typed `AnalyticsEvent` values and screen names as typed `AnalyticsScreen` values.
+- Do not use raw event strings outside the analytics catalog, and do not call PostHog or RevenueCat directly.
+- Never record personal, financial, or user-entered content in analytics.
+- Do not duplicate lifecycle, paywall, or purchase events owned by SinghDevKit.
+- Keep provider credentials in the app's existing secrets mechanism.
+- Run `$integrate-singhdevkit` after adding or renaming significant screens, Settings controls, onboarding steps, entitlements, paywalls, or purchase flows.

--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA1000052F30000100000005 /* AppAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000012F30000100000001 /* AppAnalyticsEvent.swift */; };
+		AA1000062F30000100000006 /* AppAnalyticsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1000022F30000100000002 /* AppAnalyticsScreen.swift */; };
 		AA0000062F0BC0000000002A /* PlatformTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000012F0BC0000000001A /* PlatformTypes.swift */; };
 		AA0000072F0BC0000000002B /* PasteboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000022F0BC0000000001B /* PasteboardService.swift */; };
 		AA0000082F0BC0000000002C /* HapticService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0000032F0BC0000000001C /* HapticService.swift */; };
@@ -72,6 +74,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AA1000012F30000100000001 /* AppAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAnalyticsEvent.swift; sourceTree = "<group>"; };
+		AA1000022F30000100000002 /* AppAnalyticsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAnalyticsScreen.swift; sourceTree = "<group>"; };
 		CD2900012F21000100000001 /* cardsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cardsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA0000012F0BC0000000001A /* PlatformTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformTypes.swift; sourceTree = "<group>"; };
 		AA0000022F0BC0000000001B /* PasteboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteboardService.swift; sourceTree = "<group>"; };
@@ -151,6 +155,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AA1000032F30000100000003 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				AA1000012F30000100000001 /* AppAnalyticsEvent.swift */,
+				AA1000022F30000100000002 /* AppAnalyticsScreen.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		AA00000B2F0BC0000000003A /* Platform */ = {
 			isa = PBXGroup;
 			children = (
@@ -245,6 +258,7 @@
 				EE7AF3E82B4C3A1300F2F7C0 /* Info.plist */,
 				FF9452F82BDE314E00731D8B /* Secrets.plist */,
 				EEBB52E92B238D6600035B92 /* CreditCard.swift */,
+				AA1000032F30000100000003 /* Analytics */,
 				EE1D3E8D2B66AE2A009733A5 /* Home */,
 				EE1D3E932B66B133009733A5 /* CardView */,
 				EEBED8C92B6D7F8A00BEBE87 /* ScanView */,
@@ -444,6 +458,8 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/cards/Analytics/AppAnalyticsEvent.swift",
+				"$(SRCROOT)/cards/Analytics/AppAnalyticsScreen.swift",
 				"$(SRCROOT)/cards/CardView/CardView.swift",
 				"$(SRCROOT)/cards/CardView/CardViewModel.swift",
 				"$(SRCROOT)/cards/CardView/Tip.swift",
@@ -490,6 +506,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA1000052F30000100000005 /* AppAnalyticsEvent.swift in Sources */,
+				AA1000062F30000100000006 /* AppAnalyticsScreen.swift in Sources */,
 				EE1D3E922B66AE83009733A5 /* CardViewModel.swift in Sources */,
 				EE599BAC2B23900A002F49F8 /* AppSettingsView.swift in Sources */,
 				EE8ADBEF2B66A5B600F0DC29 /* HomeViewModel.swift in Sources */,

--- a/cards/Analytics/AppAnalyticsEvent.swift
+++ b/cards/Analytics/AppAnalyticsEvent.swift
@@ -1,0 +1,119 @@
+import SinghDevKit
+
+enum AppAnalyticsEvent: AnalyticsEvent {
+    enum CardCategory: String, Sendable {
+        case creditCard = "credit_card"
+        case debitCard = "debit_card"
+        case otherCard = "other_card"
+
+        init(_ cardType: CardType) {
+            switch cardType {
+            case .creditCard:
+                self = .creditCard
+            case .debitCard:
+                self = .debitCard
+            case .otherCard:
+                self = .otherCard
+            }
+        }
+    }
+
+    enum SaveOperation: String, Sendable {
+        case create
+        case update
+    }
+
+    enum InputMethod: String, Sendable {
+        case manual
+        case scanner
+    }
+
+    enum CardLocation: String, Sendable {
+        case active
+        case archived
+    }
+
+    case cardAddStarted(cardCategory: CardCategory)
+    case cardSaveCompleted(
+        operation: SaveOperation,
+        cardCategory: CardCategory,
+        inputMethod: InputMethod
+    )
+    case cardSaveFailed(
+        operation: SaveOperation,
+        cardCategory: CardCategory,
+        inputMethod: InputMethod
+    )
+    case cardDeleted(cardCategory: CardCategory, location: CardLocation)
+    case cardDeleteFailed(cardCategory: CardCategory, location: CardLocation)
+    case cardArchived(cardCategory: CardCategory)
+    case cardArchiveFailed(cardCategory: CardCategory)
+    case cardUnarchived(cardCategory: CardCategory)
+    case cardUnarchiveFailed(cardCategory: CardCategory)
+    case cardScanStarted
+    case cardScanCompleted
+    case cardScanPermissionDenied
+    case cardOpenedFromWidget
+
+    var name: String {
+        switch self {
+        case .cardAddStarted:
+            "card_add_started"
+        case .cardSaveCompleted:
+            "card_save_completed"
+        case .cardSaveFailed:
+            "card_save_failed"
+        case .cardDeleted:
+            "card_deleted"
+        case .cardDeleteFailed:
+            "card_delete_failed"
+        case .cardArchived:
+            "card_archived"
+        case .cardArchiveFailed:
+            "card_archive_failed"
+        case .cardUnarchived:
+            "card_unarchived"
+        case .cardUnarchiveFailed:
+            "card_unarchive_failed"
+        case .cardScanStarted:
+            "card_scan_started"
+        case .cardScanCompleted:
+            "card_scan_completed"
+        case .cardScanPermissionDenied:
+            "card_scan_permission_denied"
+        case .cardOpenedFromWidget:
+            "card_opened_from_widget"
+        }
+    }
+
+    var properties: AnalyticsProperties {
+        switch self {
+        case .cardAddStarted(let cardCategory),
+             .cardArchived(let cardCategory),
+             .cardArchiveFailed(let cardCategory),
+             .cardUnarchived(let cardCategory),
+             .cardUnarchiveFailed(let cardCategory):
+            cardProperties(cardCategory)
+        case .cardSaveCompleted(let operation, let cardCategory, let inputMethod),
+             .cardSaveFailed(let operation, let cardCategory, let inputMethod):
+            cardProperties(cardCategory).merging([
+                "operation": .string(operation.rawValue),
+                "input_method": .string(inputMethod.rawValue)
+            ]) { _, newValue in newValue }
+        case .cardDeleted(let cardCategory, let location),
+             .cardDeleteFailed(let cardCategory, let location):
+            cardProperties(cardCategory).merging([
+                "location": .string(location.rawValue)
+            ]) { _, newValue in newValue }
+        case .cardScanStarted,
+             .cardScanCompleted,
+             .cardScanPermissionDenied,
+             .cardOpenedFromWidget:
+            [:]
+        }
+    }
+
+    private func cardProperties(_ cardCategory: CardCategory) -> AnalyticsProperties {
+        ["card_category": .string(cardCategory.rawValue)]
+    }
+}

--- a/cards/Analytics/AppAnalyticsScreen.swift
+++ b/cards/Analytics/AppAnalyticsScreen.swift
@@ -1,0 +1,15 @@
+import SinghDevKit
+
+enum AppAnalyticsScreen: String, AnalyticsScreen {
+    case home
+    case cardDetails = "card_details"
+    case cardEditor = "card_editor"
+    case archivedCards = "archived_cards"
+    case settings
+    case cardScanner = "card_scanner"
+    case menuBar = "menu_bar"
+
+    var name: String { rawValue }
+
+    var properties: AnalyticsProperties { [:] }
+}

--- a/cards/CardView/CardView.swift
+++ b/cards/CardView/CardView.swift
@@ -5,6 +5,7 @@
 //  Created by Pushpinder Pal Singh on 09/12/23.
 //
 
+import SinghDevKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -18,6 +19,7 @@ struct CardView: View {
 
 	@ObservedObject var model: CardViewModel
 	@Environment(\.scenePhase) var scenePhase
+	@Environment(\.analytics) private var analytics
 	#if os(macOS)
 	@State private var copiedField: String?
 	#endif
@@ -39,11 +41,21 @@ struct CardView: View {
 			.onAppear {
 				model.authenticateUser()
 			}
+			.sdkScreen(
+				model.isAddNewFlow
+					? AppAnalyticsScreen.cardEditor
+					: AppAnalyticsScreen.cardDetails
+			)
 		#else
 		getCardListView()
 			.onAppear {
 				model.authenticateUser()
 			}
+			.sdkScreen(
+				model.isAddNewFlow
+					? AppAnalyticsScreen.cardEditor
+					: AppAnalyticsScreen.cardDetails
+			)
 		#endif
 	}
 
@@ -314,10 +326,7 @@ struct CardView: View {
 			}
 			Button(action: {
 				model.isEditing.toggle()
-				// if user is not editing, then he is done editing when button press
-				if !$model.isEditing.wrappedValue && (model.card.type == .otherCard || !model.card.number.isEmpty){
-					model.addUpdateCard(model.card)
-				}
+				saveCardIfNeeded()
 			}) {
 				Text(model.isEditing ? "Done" : "Edit")
 			}
@@ -328,6 +337,7 @@ struct CardView: View {
 			if model.card.number.isEmpty {
 				ToolbarItem(placement: .topBarLeading) {
 					Button(action: {
+						track(.cardScanStarted)
 						model.isShowingScanner = true
 					}, label: {
 						Image(systemName: "camera.on.rectangle")
@@ -338,18 +348,20 @@ struct CardView: View {
 					.fullScreenCover(isPresented: $model.isShowingScanner) {
 						SharkCardScanViewRepresentable(
 							noPermissionAction: {
-								print("Error No Permission")
+								track(.cardScanPermissionDenied)
 							},
 							successHandler: { response in
 								DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
 									model.card.number = response.number
 									model.card.name = response.holder ?? ""
 									model.card.expiration = response.expiry ?? ""
+									model.markScannerCompleted()
+									track(.cardScanCompleted)
 									model.isShowingScanner = false
-									print(response.number, response.holder as Any, response.expiry as Any)
 								}
 							}
 						)
+						.sdkScreen(AppAnalyticsScreen.cardScanner)
 					}
 				}
 			}
@@ -371,6 +383,36 @@ struct CardView: View {
 				model.isAuthenticated = false
 			}
 		})
+	}
+
+	private func saveCardIfNeeded() {
+		guard !model.isEditing,
+			  model.card.type == .otherCard || !model.card.number.isEmpty else {
+			return
+		}
+
+		let operation: AppAnalyticsEvent.SaveOperation = model.isAddNewFlow ? .create : .update
+		let inputMethod: AppAnalyticsEvent.InputMethod = model.didUseScanner ? .scanner : .manual
+		let cardCategory = AppAnalyticsEvent.CardCategory(model.card.type)
+		let succeeded = model.addUpdateCard(model.card)
+		let event: AppAnalyticsEvent = succeeded
+			? .cardSaveCompleted(
+				operation: operation,
+				cardCategory: cardCategory,
+				inputMethod: inputMethod
+			)
+			: .cardSaveFailed(
+				operation: operation,
+				cardCategory: cardCategory,
+				inputMethod: inputMethod
+			)
+		track(event)
+	}
+
+	private func track(_ event: AppAnalyticsEvent) {
+		Task {
+			await analytics.capture(event)
+		}
 	}
 
 	#if os(macOS)
@@ -432,9 +474,7 @@ struct CardView: View {
 			}
 			Button(action: {
 				model.isEditing.toggle()
-				if !model.isEditing && (model.card.type == .otherCard || !model.card.number.isEmpty) {
-					model.addUpdateCard(model.card)
-				}
+				saveCardIfNeeded()
 			}) {
 				Text(model.isEditing ? "Done" : "Edit")
 			}

--- a/cards/CardView/CardViewModel.swift
+++ b/cards/CardView/CardViewModel.swift
@@ -21,15 +21,16 @@ class CardViewModel: ObservableObject {
 	@Published var isShowingScanner = false
 	@Published var errorMessage: String?
 	@Published var showErrorAlert = false
+	private(set) var didUseScanner = false
 
 	#if os(iOS)
 	@Published var selectedItem: PhotosPickerItem?
 	#endif
 
 	var isAddNewFlow : Bool
-	var addUpdateCard: (CardData) -> Void
+	var addUpdateCard: (CardData) -> Bool
 
-	init(card: CardData, isEditing: Bool = false, addNewFlow: Bool = false, addUpdateCard: @escaping ((CardData) -> Void) ) {
+	init(card: CardData, isEditing: Bool = false, addNewFlow: Bool = false, addUpdateCard: @escaping ((CardData) -> Bool) ) {
 		self.card = card
 		self.isEditing = isEditing
 		self.addUpdateCard = addUpdateCard
@@ -77,5 +78,9 @@ class CardViewModel: ObservableObject {
 		}
 		PasteboardService.copy(value)
 		HapticService.trigger(.success)
+	}
+
+	func markScannerCompleted() {
+		didUseScanner = true
 	}
 }

--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -79,7 +79,6 @@ struct CreditCard: App {
                         whatsNewCollection: self
                      )
                 )
-                .withSDK(.shared)
                 .showOnboardingIfNeeded(features: [.init(image: Image(systemName: "lock.shield"),
                                                          title: "Secure Storage",
                                                          content: "Keep your card details safe with state-of-the-art encryption."),
@@ -93,6 +92,7 @@ struct CreditCard: App {
                                                          title: "Privacy First, Open Source",
                                                          content: "Your data stays private and secure, and the app's code is open-source for transparency.")]
                 )
+                .withSDK(.shared)
         }
         #if os(macOS)
         menuBarScene
@@ -104,6 +104,7 @@ struct CreditCard: App {
     var menuBarScene: some Scene {
         MenuBarExtra("Holder", systemImage: "creditcard.fill") {
             MenuBarView(cardStore: cardDataStore)
+                .withSDK(.shared)
         }
         .menuBarExtraStyle(.window)
     }
@@ -111,6 +112,7 @@ struct CreditCard: App {
     var settingsScene: some Scene {
         SwiftUI.Settings {
             SettingsView(configuration: SettingsViewModel())
+                .sdkScreen(AppAnalyticsScreen.settings)
                 .withSDK(.shared)
                 .presentationSizing(.fitted)
                 .frame(minWidth: 620, minHeight: 480)
@@ -144,9 +146,6 @@ private actor SDKBootstrapper {
                     payments: appSecrets.paymentsConfiguration
                 )
             )
-            if appSecrets.isAnalyticsEnabled {
-                await SinghDevKit.shared.analytics.trackAppLaunch()
-            }
             state = .configured
         } catch {
             state = .failed
@@ -168,10 +167,6 @@ struct AppSecrets: Sendable {
 
     var paymentsConfiguration: PaymentsConfiguration {
         revenueCatAPIKey.map { .revenueCat(apiKey: $0) } ?? .disabled
-    }
-
-    var isAnalyticsEnabled: Bool {
-        postHogProjectToken != nil
     }
 
     static func load() -> Self {

--- a/cards/Home/ArchivedCardsView.swift
+++ b/cards/Home/ArchivedCardsView.swift
@@ -5,10 +5,12 @@
 //  View for displaying and managing archived cards
 //
 
+import SinghDevKit
 import SwiftUI
 
 struct ArchivedCardsView: View {
 	@ObservedObject var model: HomeViewModel
+	@Environment(\.analytics) private var analytics
 
 	var body: some View {
 		List {
@@ -23,12 +25,12 @@ struct ArchivedCardsView: View {
 					cardRow(for: card)
 						.swipeActions(edge: .trailing, allowsFullSwipe: false) {
 							Button(role: .destructive) {
-								model.deleteArchivedCard(card)
+								deleteCard(card)
 							} label: {
 								Label("Delete", systemImage: "trash")
 							}
 							Button {
-								model.unarchiveCard(card)
+								unarchiveCard(card)
 							} label: {
 								Label("Unarchive", systemImage: "arrow.uturn.backward")
 							}
@@ -36,12 +38,12 @@ struct ArchivedCardsView: View {
 						}
 						.contextMenu {
 							Button {
-								model.unarchiveCard(card)
+								unarchiveCard(card)
 							} label: {
 								Label("Unarchive", systemImage: "arrow.uturn.backward")
 							}
 							Button(role: .destructive) {
-								model.deleteArchivedCard(card)
+								deleteCard(card)
 							} label: {
 								Label("Delete", systemImage: "trash")
 							}
@@ -50,6 +52,27 @@ struct ArchivedCardsView: View {
 			}
 		}
 		.navigationTitle("Archived Cards")
+		.sdkScreen(AppAnalyticsScreen.archivedCards)
+	}
+
+	private func deleteCard(_ card: CardData) {
+		let event: AppAnalyticsEvent = model.deleteArchivedCard(card)
+			? .cardDeleted(cardCategory: .init(card.type), location: .archived)
+			: .cardDeleteFailed(cardCategory: .init(card.type), location: .archived)
+		track(event)
+	}
+
+	private func unarchiveCard(_ card: CardData) {
+		let event: AppAnalyticsEvent = model.unarchiveCard(card)
+			? .cardUnarchived(cardCategory: .init(card.type))
+			: .cardUnarchiveFailed(cardCategory: .init(card.type))
+		track(event)
+	}
+
+	private func track(_ event: AppAnalyticsEvent) {
+		Task {
+			await analytics.capture(event)
+		}
 	}
 
 	private func cardRow(for card: CardData) -> some View {

--- a/cards/Home/HomeView.swift
+++ b/cards/Home/HomeView.swift
@@ -11,6 +11,7 @@ import SinghDevKit
 
 struct HomeView: View {
 	@ObservedObject var model: HomeViewModel
+	@Environment(\.analytics) private var analytics
 
 	init(cardDataStore: CardDataStore = CardDataStore()) {
 		self.model = HomeViewModel(cardDataStore: cardDataStore)
@@ -25,13 +26,12 @@ struct HomeView: View {
 							getRowforCards(with: card)
 								.swipeActions(edge: .trailing, allowsFullSwipe: false) {
 									Button(role: .destructive) {
-										_ = model.cardDataStore.deleteCard(with: card.id)
-										model.cardDataStore.cardsByType[type]?.removeAll { $0.id == card.id }
+										deleteCard(card)
 									} label: {
 										Label("Delete", systemImage: "trash")
 									}
 									Button {
-										model.archiveCard(card)
+										archiveCard(card)
 									} label: {
 										Label("Archive", systemImage: "archivebox")
 									}
@@ -39,19 +39,19 @@ struct HomeView: View {
 								}
 								.contextMenu {
 									Button {
-										model.archiveCard(card)
+										archiveCard(card)
 									} label: {
 										Label("Archive", systemImage: "archivebox")
 									}
 									Button(role: .destructive) {
-										_ = model.cardDataStore.deleteCard(with: card.id)
-										model.cardDataStore.cardsByType[type]?.removeAll { $0.id == card.id }
+										deleteCard(card)
 									} label: {
 										Label("Delete", systemImage: "trash")
 									}
 								}
 						}
 						Button("Add a new \(type.rawValue)") {
+							track(.cardAddStarted(cardCategory: .init(type)))
 							model.addingType = type
 						}
 					}
@@ -76,7 +76,10 @@ struct HomeView: View {
 			}
 			#if !os(macOS)
 			.toolbar {
-				NavigationLink(destination: SettingsView(configuration: SettingsViewModel())) {
+				NavigationLink(
+					destination: SettingsView(configuration: SettingsViewModel())
+						.sdkScreen(AppAnalyticsScreen.settings)
+				) {
 					Image(systemName: "gear")
 				}
 			}
@@ -103,7 +106,9 @@ struct HomeView: View {
 		}
 		.whatsNewSheet()
 		.onOpenURL { url in
-			model.handleDeepLink(url)
+			model.handleDeepLink(url, onOpenedFromWidget: {
+				track(.cardOpenedFromWidget)
+			})
 		}
 		.navigationDestination(item: $model.selectedCard) { card in
 			CardView(model: CardViewModel(
@@ -126,14 +131,33 @@ struct HomeView: View {
 					isEditing: true,
 					addNewFlow: true,
 					addUpdateCard: { card in
-						model.cardDataStore.addCard(card)
+						let succeeded = model.cardDataStore.addCard(card)
 						model.addingType = nil
-						Task { @MainActor in
-							model.cardDataStore.loadCards()
-						}
+						return succeeded
 					})
 				)
 			}
+		}
+		.sdkScreen(AppAnalyticsScreen.home)
+	}
+
+	private func deleteCard(_ card: CardData) {
+		let event: AppAnalyticsEvent = model.cardDataStore.deleteCard(with: card.id)
+			? .cardDeleted(cardCategory: .init(card.type), location: .active)
+			: .cardDeleteFailed(cardCategory: .init(card.type), location: .active)
+		track(event)
+	}
+
+	private func archiveCard(_ card: CardData) {
+		let event: AppAnalyticsEvent = model.archiveCard(card)
+			? .cardArchived(cardCategory: .init(card.type))
+			: .cardArchiveFailed(cardCategory: .init(card.type))
+		track(event)
+	}
+
+	private func track(_ event: AppAnalyticsEvent) {
+		Task {
+			await analytics.capture(event)
 		}
 	}
 

--- a/cards/Home/HomeViewModel.swift
+++ b/cards/Home/HomeViewModel.swift
@@ -13,9 +13,14 @@ class HomeViewModel: ObservableObject {
 	@Published var selectedCard: CardData?
 	@Bindable var cardDataStore: CardDataStore
 	@AppStorage("isFirstLaunch") var isFirstLaunch = true
+	private var deepLinkTask: Task<Void, Never>?
 
 	init(cardDataStore: CardDataStore = CardDataStore()) {
 		self.cardDataStore = cardDataStore
+	}
+
+	deinit {
+		deepLinkTask?.cancel()
 	}
 
 	var appName: String? {
@@ -23,34 +28,32 @@ class HomeViewModel: ObservableObject {
 	}
 
 	func deleteCard(at offsets: IndexSet, inSection cardType: CardType) {
-		offsets.forEach { index in
-			guard let card = cardDataStore.cardsByType[cardType]?[index] else { return }
-			if cardDataStore.deleteCard(with: card.id) {
-				cardDataStore.cardsByType[cardType]?.remove(at: index)
-			} else {
+		let cards = offsets.compactMap { cardDataStore.cardsByType[cardType]?[$0] }
+		for card in cards {
+			if !cardDataStore.deleteCard(with: card.id) {
 				print("Error deleting")
 			}
 		}
 	}
 
-	func archiveCard(_ card: CardData) {
+	@discardableResult
+	func archiveCard(_ card: CardData) -> Bool {
 		cardDataStore.archiveCard(card)
 	}
 
-	func unarchiveCard(_ card: CardData) {
+	@discardableResult
+	func unarchiveCard(_ card: CardData) -> Bool {
 		cardDataStore.unarchiveCard(card)
 	}
 
-	func deleteArchivedCard(_ card: CardData) {
-		if cardDataStore.deleteCard(with: card.id) {
-			if let index = cardDataStore.archivedCards.firstIndex(where: { $0.id == card.id }) {
-				cardDataStore.archivedCards.remove(at: index)
-			}
-		}
+	@discardableResult
+	func deleteArchivedCard(_ card: CardData) -> Bool {
+		cardDataStore.deleteCard(with: card.id)
 	}
 
 	/// Handles deep link URL from widget (holder://card/{uuid})
-	func handleDeepLink(_ url: URL) {
+	/// - Parameter onOpenedFromWidget: Invoked only after a matching card is selected.
+	func handleDeepLink(_ url: URL, onOpenedFromWidget: (() -> Void)? = nil) {
 		guard url.scheme == "holder",
 			  url.host == "card",
 			  let cardIDString = url.pathComponents.last,
@@ -58,33 +61,51 @@ class HomeViewModel: ObservableObject {
 			return
 		}
 
-		Task { @MainActor in
+		deepLinkTask?.cancel()
+		deepLinkTask = Task { @MainActor [weak self] in
+			guard let self else { return }
+
 			// Ensure cards are loaded before trying to find the card
 			if cardDataStore.cardsByType.values.allSatisfy({ $0.isEmpty }) {
 				cardDataStore.loadCards()
 			}
 
 			// Retry finding the card with exponential backoff instead of fixed delay
-			await findAndSelectCard(by: cardID)
+			await findAndSelectCard(by: cardID, onOpenedFromWidget: onOpenedFromWidget)
 		}
 	}
 
 	/// Attempts to find and select a card with retries
 	@MainActor
-	private func findAndSelectCard(by cardID: UUID, attempt: Int = 0) async {
+	private func findAndSelectCard(
+		by cardID: UUID,
+		attempt: Int = 0,
+		onOpenedFromWidget: (() -> Void)? = nil
+	) async {
+		guard !Task.isCancelled else { return }
+
 		let maxAttempts = 5
 		let baseDelay: UInt64 = 50_000_000 // 50ms
 
 		if let card = cardDataStore.findCard(by: cardID) {
 			selectedCard = card
+			onOpenedFromWidget?()
 			return
 		}
 
 		// Retry with exponential backoff if card not found
 		if attempt < maxAttempts {
 			let delay = baseDelay * UInt64(1 << attempt) // 50ms, 100ms, 200ms, 400ms, 800ms
-			try? await Task.sleep(nanoseconds: delay)
-			await findAndSelectCard(by: cardID, attempt: attempt + 1)
+			do {
+				try await Task.sleep(nanoseconds: delay)
+			} catch {
+				return
+			}
+			await findAndSelectCard(
+				by: cardID,
+				attempt: attempt + 1,
+				onOpenedFromWidget: onOpenedFromWidget
+			)
 		}
 	}
 }

--- a/cards/Model/CardDataStore.swift
+++ b/cards/Model/CardDataStore.swift
@@ -17,6 +17,7 @@ class CardDataStore {
 
 	private let appGroupID = "group.com.swiftlysingh.cards"
 	private let widgetCardsKey = "widgetAvailableCards"
+	private let debugFixturesInitializedKey = "debugFixturesInitialized"
 
 	private var sharedDefaults: UserDefaults? {
 		UserDefaults(suiteName: appGroupID)
@@ -36,9 +37,14 @@ class CardDataStore {
 
 	func loadCards() {
 		var retrievedCard = retrieveAllCardData(service: Bundle.main.bundleIdentifier ?? "com.myApp.defaultService") ?? []
+		let hasInitializedDebugFixtures = UserDefaults.standard.bool(forKey: debugFixturesInitializedKey)
 
 			//		Add default data for simulator
-		if isDebugOrSimulator && retrievedCard.isEmpty {
+		if Self.shouldSeedDebugFixtures(
+			isDebugOrSimulator: isDebugOrSimulator,
+			hasStoredCards: !retrievedCard.isEmpty,
+			hasInitializedFixtures: hasInitializedDebugFixtures
+		) {
 			let fixtures = [
 				CardData(id: UUID(), number: "4234567890123456", cvv: "123", expiration: "12/25", name: "John Doe", description: "Axis Visa", type: .creditCard, network: "4234567890123456".getCardNetwork()),
 				CardData(id: UUID(), number: "5345678901234567", cvv: "234", expiration: "11/24", name: "Jane Smith", description: "SBI MasterCard", type: .creditCard, network: "5345678901234567".getCardNetwork()),
@@ -71,10 +77,21 @@ class CardDataStore {
 				}
 			}
 		}
+		if isDebugOrSimulator && !hasInitializedDebugFixtures && !retrievedCard.isEmpty {
+			UserDefaults.standard.set(true, forKey: debugFixturesInitializedKey)
+		}
 		let partition = Self.partition(retrievedCard)
 		cardsByType = partition.cardsByType
 		archivedCards = partition.archivedCards
 		syncCardsToWidget()
+	}
+
+	static func shouldSeedDebugFixtures(
+		isDebugOrSimulator: Bool,
+		hasStoredCards: Bool,
+		hasInitializedFixtures: Bool
+	) -> Bool {
+		isDebugOrSimulator && !hasStoredCards && !hasInitializedFixtures
 	}
 
 	static func partition(_ cards: [CardData]) -> (cardsByType: [CardType: [CardData]], archivedCards: [CardData]) {

--- a/cards/Model/CardDataStore.swift
+++ b/cards/Model/CardDataStore.swift
@@ -83,10 +83,13 @@ class CardDataStore {
 		return (cardsByType, cards.filter { $0.isArchived })
 	}
 
-	func addCard(_ card: CardData) {
-		//TODO: Add error handling here
-		_ = saveOrUpdateCardData(card)
-		syncCardsToWidget()
+	@discardableResult
+	func addCard(_ card: CardData) -> Bool {
+		let succeeded = saveOrUpdateCardData(card)
+		if succeeded {
+			loadCards()
+		}
+		return succeeded
 	}
 
 	/// Finds a card by its UUID (used for deep linking from widgets)
@@ -108,30 +111,50 @@ class CardDataStore {
 		]
 
 		let status = SecItemDelete(query as CFDictionary)
+		let containsInMemoryCard = cardsByType.values.contains { cards in
+			cards.contains { $0.id == id }
+		} || archivedCards.contains { $0.id == id }
+		let deletedPersistedCard = status == errSecSuccess
+		let deletedDebugCard = isDebugOrSimulator
+			&& status == errSecItemNotFound
+			&& containsInMemoryCard
+		guard deletedPersistedCard || deletedDebugCard else {
+			return false
+		}
+
+		// Drop in-memory copies before widget sync so timelines match persistence.
+		for type in CardType.allCases {
+			cardsByType[type]?.removeAll { $0.id == id }
+		}
+		archivedCards.removeAll { $0.id == id }
 		syncCardsToWidget()
-		return status == errSecSuccess
+		return true
 	}
 
 	// MARK: - Archive
 
-	func archiveCard(_ card: CardData) {
+	@discardableResult
+	func archiveCard(_ card: CardData) -> Bool {
 		var archivedCard = card
 		archivedCard.isArchived = true
 		guard saveOrUpdateCardData(archivedCard) else {
 			print("Failed to archive card: \(card.id)")
-			return
+			return false
 		}
 		loadCards()
+		return true
 	}
 
-	func unarchiveCard(_ card: CardData) {
+	@discardableResult
+	func unarchiveCard(_ card: CardData) -> Bool {
 		var unarchivedCard = card
 		unarchivedCard.isArchived = false
 		guard saveOrUpdateCardData(unarchivedCard) else {
 			print("Failed to unarchive card: \(card.id)")
-			return
+			return false
 		}
 		loadCards()
+		return true
 	}
 /// Returns if success
 	private func saveOrUpdateCardData(_ cardData: CardData) -> Bool {

--- a/cards/Model/CardDataStore.swift
+++ b/cards/Model/CardDataStore.swift
@@ -39,35 +39,37 @@ class CardDataStore {
 
 			//		Add default data for simulator
 		if isDebugOrSimulator && retrievedCard.isEmpty {
-			retrievedCard.append(
-				contentsOf: [
-					CardData(id: UUID(), number: "4234567890123456", cvv: "123", expiration: "12/25", name: "John Doe", description: "Axis Visa", type: .creditCard, network: "4234567890123456".getCardNetwork()),
-					CardData(id: UUID(), number: "5345678901234567", cvv: "234", expiration: "11/24", name: "Jane Smith", description: "SBI MasterCard", type: .creditCard, network: "5345678901234567".getCardNetwork()),
-					CardData(id: UUID(), number: "34567890123456", cvv: "345", expiration: "10/23", name: "Alex Johnson", description: "American Express Gold", type: .creditCard, network: "34567890123456".getCardNetwork()),
-					CardData(id: UUID(), number: "6067890123456789", cvv: "456", expiration: "08/26", name: "Emily Davis", description: "Kotak PVR", type: .debitCard, network: "6067890123456789".getCardNetwork()),
-					CardData(
-						id: UUID(),
-						number: "3678901234567890",
-						cvv: "567",
-						expiration: "07/25",
-						name: "Michael Brown",
-						description: "HDFC Platinum",
-						type: .debitCard,
-						network: "3678901234567890".getCardNetwork()
-					),
-					CardData(
-						id: UUID(),
-						number: "3678901234567890",
-						cvv: "567",
-						expiration: "07/25",
-						name: "Michael Brown",
-						description: "HDFC Platinum",
-						type: .otherCard,
-						network: "3678901234567890".getCardNetwork()
-					)
-				]
-			)
-
+			let fixtures = [
+				CardData(id: UUID(), number: "4234567890123456", cvv: "123", expiration: "12/25", name: "John Doe", description: "Axis Visa", type: .creditCard, network: "4234567890123456".getCardNetwork()),
+				CardData(id: UUID(), number: "5345678901234567", cvv: "234", expiration: "11/24", name: "Jane Smith", description: "SBI MasterCard", type: .creditCard, network: "5345678901234567".getCardNetwork()),
+				CardData(id: UUID(), number: "34567890123456", cvv: "345", expiration: "10/23", name: "Alex Johnson", description: "American Express Gold", type: .creditCard, network: "34567890123456".getCardNetwork()),
+				CardData(id: UUID(), number: "6067890123456789", cvv: "456", expiration: "08/26", name: "Emily Davis", description: "Kotak PVR", type: .debitCard, network: "6067890123456789".getCardNetwork()),
+				CardData(
+					id: UUID(),
+					number: "3678901234567890",
+					cvv: "567",
+					expiration: "07/25",
+					name: "Michael Brown",
+					description: "HDFC Platinum",
+					type: .debitCard,
+					network: "3678901234567890".getCardNetwork()
+				),
+				CardData(
+					id: UUID(),
+					number: "3678901234567890",
+					cvv: "567",
+					expiration: "07/25",
+					name: "Michael Brown",
+					description: "HDFC Platinum",
+					type: .otherCard,
+					network: "3678901234567890".getCardNetwork()
+				)
+			]
+			for fixture in fixtures {
+				if saveOrUpdateCardData(fixture) {
+					retrievedCard.append(fixture)
+				}
+			}
 		}
 		let partition = Self.partition(retrievedCard)
 		cardsByType = partition.cardsByType
@@ -110,15 +112,7 @@ class CardDataStore {
 			kSecAttrSynchronizable as String: kCFBooleanTrue!
 		]
 
-		let status = SecItemDelete(query as CFDictionary)
-		let containsInMemoryCard = cardsByType.values.contains { cards in
-			cards.contains { $0.id == id }
-		} || archivedCards.contains { $0.id == id }
-		let deletedPersistedCard = status == errSecSuccess
-		let deletedDebugCard = isDebugOrSimulator
-			&& status == errSecItemNotFound
-			&& containsInMemoryCard
-		guard deletedPersistedCard || deletedDebugCard else {
+		guard SecItemDelete(query as CFDictionary) == errSecSuccess else {
 			return false
 		}
 

--- a/cards/Settings/AppSettingsView.swift
+++ b/cards/Settings/AppSettingsView.swift
@@ -45,7 +45,10 @@ struct AppSettingsView: View {
             Label("Support Holder", systemImage: "heart.fill")
         }
         .sheet(isPresented: $showsTipJar) {
-            SDKPaywallView(displayCloseButton: true)
+            SDKPaywallView(
+                displayCloseButton: true,
+                analyticsContext: SDKPaywallContext(source: "settings_support")
+            )
         }
     }
 }

--- a/cards/macOS/MenuBarView.swift
+++ b/cards/macOS/MenuBarView.swift
@@ -6,9 +6,10 @@
 //
 
 #if os(macOS)
-import SwiftUI
 import AppKit
 import LocalAuthentication
+import SinghDevKit
+import SwiftUI
 
 struct MenuBarView: View {
     var cardStore: CardDataStore
@@ -51,6 +52,7 @@ struct MenuBarView: View {
             // Detect biometric type once
             detectBiometricType()
         }
+        .sdkScreen(AppAnalyticsScreen.menuBar)
     }
 
     private func detectBiometricType() {

--- a/cardsTests/CardDataPersistenceTests.swift
+++ b/cardsTests/CardDataPersistenceTests.swift
@@ -45,6 +45,19 @@ final class CardDataPersistenceTests: XCTestCase {
 		XCTAssertEqual(partition.archivedCards.map(\.id), [archivedCard.id])
 	}
 
+	func testDebugFixturesSeedOnlyBeforeInitialization() {
+		XCTAssertTrue(CardDataStore.shouldSeedDebugFixtures(
+			isDebugOrSimulator: true,
+			hasStoredCards: false,
+			hasInitializedFixtures: false
+		))
+		XCTAssertFalse(CardDataStore.shouldSeedDebugFixtures(
+			isDebugOrSimulator: true,
+			hasStoredCards: false,
+			hasInitializedFixtures: true
+		))
+	}
+
 	private func makeCard(
 		id: UUID,
 		type: CardType = .creditCard,


### PR DESCRIPTION
## Summary

- add typed SinghDevKit analytics event and screen catalogs for Holder
- instrument Home, card details/editor/scanner, archived cards, Settings, and the macOS menu bar
- record truthful save/delete/archive/unarchive outcomes without exposing card or OCR content
- remove duplicate app-launch tracking and ensure `.withSDK(.shared)` wraps onboarding, Settings, and menu-bar analytics consumers
- keep SinghDevKit on the latest stable release, `2.3.0`
- add persistent SinghDevKit integration guidance in `AGENTS.md`

## Coverage

| Area | Status |
| --- | --- |
| Dependency and imports | Implemented — SinghDevKit remains `2.3.0`; no direct PostHog or RevenueCat imports |
| SDK bootstrap and environment | Implemented — one configure path; onboarding, Settings, and menu bar inherit `.withSDK(.shared)` |
| Settings | Implemented through SinghDevKit's `SettingsView` (`SDKSettingsView` typealias) |
| Onboarding | Implemented and verified against a local analytics endpoint |
| Analytics events and screens | Implemented with typed catalogs |
| Diagnostics | Not applicable to this analytics-focused change |
| Payments / paywall / Customer Center | Existing SDK-owned behavior preserved; Settings support paywall now supplies a stable source context |
| Privacy and secrets | Verified — bounded enum properties only; no card values, IDs, OCR output, names, or error text |

## Analytics audits

Both the SinghDevKit `2.3.0` analytics audit and the newer upstream integration audit report:

- 0 direct vendor usages
- 0 raw analytics calls
- 0 duplicated SDK-owned events
- 0 privacy findings

Expected heuristic review candidates are intentionally uninstrumented:

- widget-extension views (`SmallCardWidgetView`, `MediumCardWidgetView`, `LockScreenCardWidgetView`, and `CardCellView`)
- embedded `AppSettingsView`, whose Settings destination wrapper is tracked

The expanded audit's Settings signal is a known text-matching false positive: SinghDevKit `2.3.0` defines `SettingsView` as a typealias of `SDKSettingsView`.

## Verification

- macOS build: passed
- generic iOS Simulator build: passed
- `cardsTests` on macOS: 7 passed, 0 failed
- audit script self-tests: passed
- independent full-diff correctness and privacy reviews: completed; no high- or medium-severity security findings
- runtime: launched an isolated ad-hoc app copy using a unique bundle ID, disabled payments, and a local PostHog-compatible capture server
  - observed `onboarding shown` from the onboarding modifier, confirming it receives the configured SDK analytics environment
  - observed `$screen` with `$screen_name: home`
  - malformed `holder://card/not-a-uuid` probe emitted no `card_opened_from_widget` event

### Remaining verification blocker

Automated interaction with the remaining native SwiftUI controls is blocked because the current terminal host does not have macOS Accessibility permission. Save, scanner, archive/unarchive/delete, Settings, paywall, and menu-bar click paths therefore remain to be driven before this PR is marked ready. The PR is intentionally opened as a draft.

## Visual evidence

Not applicable — analytics instrumentation and SDK environment correction do not alter visible UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking across key screens (home, settings, card editor/details, scanner, archived, menu bar) and card actions (create/update, scan start/finish, archive/unarchive, delete).
  * Added analytics for widget-based deep links and deep-link opens.
  * Enhanced support holder paywall presentation with analytics context.

* **Bug Fixes**
  * Improved deep-link resolution with cancellation and exponential backoff retry.
  * Tightened card persistence/sync behavior so UI refreshes only after successful saves/deletes/archiving.
  * Improved simulator/debug fixture seeding and deletion success handling.

* **Documentation**
  * Updated integration guidance for the analytics/SDK setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->