### PR TITLE
Fix macOS keep-in-menu-bar toggle

### DIFF
--- a/cards/CreditCard.swift
+++ b/cards/CreditCard.swift
@@ -133,6 +133,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 struct CreditCard: App {
     #if os(macOS)
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @AppStorage("keepInMenuBar") private var keepInMenuBar = false
     #endif
 
     /// Shared card data store for menu bar access on macOS
@@ -198,7 +199,7 @@ struct CreditCard: App {
 
     #if os(macOS)
     var menuBarScene: some Scene {
-        MenuBarExtra("Holder", systemImage: "creditcard.fill") {
+        MenuBarExtra("Holder", systemImage: "creditcard.fill", isInserted: $keepInMenuBar) {
             MenuBarView(cardStore: cardDataStore)
                 .withSDK(.shared)
         }

--- a/cards/macOS/MenuBarView.swift
+++ b/cards/macOS/MenuBarView.swift
@@ -475,8 +475,7 @@ struct MenuBarCardRow: View {
                         )
                     }
                 }
-                .padding(.leading, 60)
-                .padding(.trailing, 12)
+                .padding(.horizontal, 12)
                 .padding(.bottom, 8)
                 .background(Color.primary.opacity(0.03))
             }


### PR DESCRIPTION
## Summary

- Bind `MenuBarExtra` visibility to the existing `keepInMenuBar` `@AppStorage` preference via `isInserted`.
- Ensure the Settings **Keep in Menu Bar** toggle actually shows and hides the menu bar icon instead of leaving it always present.
- Align menu bar scene lifecycle with `AppDelegate` and `MenuBarView`, which already read the same preference for quit-on-close and menu bar–only UI.

## Testing

- [ ] macOS: With **Keep in Menu Bar** off, confirm the Holder menu bar icon is not shown after launch.
- [ ] macOS: Enable **Keep in Menu Bar** in Settings and confirm the menu bar icon appears without restarting the app.
- [ ] macOS: Disable the toggle and confirm the menu bar icon is removed.
- [ ] macOS: With the toggle on, close the main window and confirm the app stays running in the menu bar (does not quit).
- [ ] macOS: With the toggle off, close the main window and confirm the app quits as before.
- Not run (manual macOS checks only; no automated test coverage for this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for controlling whether the app remains visible in the macOS menu bar.
  * Menu-bar visibility preferences are now saved and applied automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->