### PR TITLE
Unify the Add Card flow

### DIFF
--- a/cards/CardView/CardView.swift
+++ b/cards/CardView/CardView.swift
@@ -115,16 +115,16 @@ struct CardView: View {
 					isRescan: model.didUseScanner,
 					onCancel: {
 						model.isShowingScanner = false
-						cardSheetDetent = model.entryMode == .chooser ? .fraction(0.25) : .large
+						cardSheetDetent = model.entryMode == .chooser ? .fraction(0.25) : .fraction(0.5)
 					},
 					onPermissionDenied: {
 						track(.cardScanPermissionDenied(engine: CardScanningEngineFactory.currentEngineID))
 						model.isShowingScanner = false
-						cardSheetDetent = model.entryMode == .chooser ? .fraction(0.25) : .large
+						cardSheetDetent = model.entryMode == .chooser ? .fraction(0.25) : .fraction(0.5)
 					},
 					onResult: { result, metrics in
 						model.applyScan(result)
-						cardSheetDetent = .large
+						cardSheetDetent = .fraction(0.5)
 						track(
 							.cardScanCompleted(
 								engine: metrics.engine,
@@ -190,44 +190,6 @@ struct CardView: View {
 		model.isShowingScanner = true
 	}
 
-	private func scanReviewSection() -> some View {
-		Group {
-			if model.isAuthenticated, let preview = model.lastScanPreview {
-				Section {
-					HStack(spacing: 12) {
-						Image(preview.network.rawValue)
-							.resizable()
-							.scaledToFit()
-							.frame(width: 36, height: 36)
-						VStack(alignment: .leading, spacing: 4) {
-							Text(preview.network.rawValue)
-								.font(.headline)
-							Text("•••• \(preview.lastFour)")
-								.font(.body.monospaced())
-							if let expiry = preview.expiry, !expiry.isEmpty {
-								Text("Expires \(expiry)")
-									.foregroundStyle(.secondary)
-							}
-							if let name = preview.cardholderName, !name.isEmpty {
-								Text(name)
-									.foregroundStyle(.secondary)
-							}
-						}
-						Spacer()
-					}
-					Button {
-						startScan(isRescan: true)
-					} label: {
-						Label("Scan Again", systemImage: "camera.on.rectangle")
-					}
-				} header: {
-					Text("Scanned card")
-				} footer: {
-					Text("Every field below stays editable. Missing scan values will not erase what you already entered.")
-				}
-			}
-		}
-	}
 	#endif
 
 	#if os(iOS)
@@ -299,9 +261,6 @@ struct CardView: View {
 		let tip = DoubleTapTip()
 
 		return List {
-			#if os(iOS)
-			scanReviewSection()
-			#endif
 			Section {
 				#if os(iOS)
 				let fields: [(String, Binding<String>, UIKeyboardType)] = [

--- a/cards/CardView/CardView.swift
+++ b/cards/CardView/CardView.swift
@@ -354,7 +354,7 @@ struct CardView: View {
 				#endif
 
 				Group {
-				  if model.card.type != .otherCard {
+				  if model.selectedCardType != .otherCard {
 					Picker("Card Network", selection: $model.card.network) {
 					  ForEach(CardNetwork.allCases) { pref in
 						Text(pref.rawValue)
@@ -364,9 +364,12 @@ struct CardView: View {
 					.disabled(!model.isEditing)
 					.bold()
 				  }
-					Picker("Card Type", selection: $model.card.type) {
+					Picker("Card Type", selection: $model.selectedCardType) {
+						if model.isAddNewFlow {
+							Text("Select Card Type").tag(nil as CardType?)
+						}
 						ForEach(CardType.allCases) { pref in
-							Text(pref.rawValue)
+							Text(pref.rawValue).tag(pref as CardType?)
 						}
 					}
 					.disabled(!model.isEditing)
@@ -374,7 +377,7 @@ struct CardView: View {
 				}
 			}
 
-			if let image = model.cardImage, model.card.type == .otherCard {
+			if let image = model.cardImage, model.selectedCardType == .otherCard {
 				Section {
 					#if os(iOS)
 					Image(uiImage: image)
@@ -395,7 +398,7 @@ struct CardView: View {
 			}
 
 			#if os(iOS)
-			if model.isEditing && model.card.type == .otherCard {
+			if model.isEditing && model.selectedCardType == .otherCard {
 				Section {
 					PhotosPicker(selection: $model.selectedItem, matching: .images) {
 						VStack(alignment: .leading) {
@@ -449,7 +452,7 @@ struct CardView: View {
 				}
 			}
 			#else
-			if model.isEditing && model.card.type == .otherCard {
+			if model.isEditing && model.selectedCardType == .otherCard {
 				Section {
 					Button {
 						selectImageFile()
@@ -499,16 +502,20 @@ struct CardView: View {
 				Label("Click to share", systemImage: "square.and.arrow.up")
 			}
 			Button(action: {
-				model.isEditing.toggle()
-				saveCardIfNeeded()
+				if model.isEditing {
+					saveCardIfNeeded()
+				} else {
+					model.isEditing = true
+				}
 			}) {
 				Text(model.isEditing ? "Done" : "Edit")
 			}
+			.disabled(model.isEditing && !model.canFinishEditing)
 		}
 		.disabled(!$model.isAuthenticated.wrappedValue)
 		#if os(iOS)
 		.toolbar {
-			if model.isAddNewFlow && model.card.type != .otherCard && model.entryMode == .form {
+			if model.isAddNewFlow && model.selectedCardType != .otherCard && model.entryMode == .form {
 				ToolbarItem(placement: .topBarLeading) {
 					Button {
 						startScan(isRescan: model.didUseScanner)
@@ -525,14 +532,14 @@ struct CardView: View {
 	}
 
 	private func saveCardIfNeeded() {
-		guard !model.isEditing,
-			  model.card.type == .otherCard || !model.card.number.isEmpty else {
-			return
-		}
+		guard model.isEditing, model.canFinishEditing else { return }
 
 		let operation: AppAnalyticsEvent.SaveOperation = model.isAddNewFlow ? .create : .update
 		let inputMethod: AppAnalyticsEvent.InputMethod = model.didUseScanner ? .scanner : .manual
 		let succeeded = model.addUpdateCard(model.card)
+		if succeeded {
+			model.isEditing = false
+		}
 		let event: AppAnalyticsEvent = succeeded
 			? .cardSaveCompleted(
 				operation: operation,
@@ -578,12 +585,12 @@ struct CardView: View {
 		ScrollView {
 			VStack(spacing: 24) {
 				// Visual Card Preview (only for credit/debit cards)
-				if model.card.type != .otherCard && model.isAuthenticated && !model.isEditing {
+				if model.selectedCardType != .otherCard && model.isAuthenticated && !model.isEditing {
 					macOSCardPreview()
 				}
 
 				// Card Image for Other Cards
-				if let image = model.cardImage, model.card.type == .otherCard {
+				if let image = model.cardImage, model.selectedCardType == .otherCard {
 					Image(nsImage: image)
 						.resizable()
 						.scaledToFit()
@@ -609,11 +616,15 @@ struct CardView: View {
 				Label("Share", systemImage: "square.and.arrow.up")
 			}
 			Button(action: {
-				model.isEditing.toggle()
-				saveCardIfNeeded()
+				if model.isEditing {
+					saveCardIfNeeded()
+				} else {
+					model.isEditing = true
+				}
 			}) {
 				Text(model.isEditing ? "Done" : "Edit")
 			}
+			.disabled(model.isEditing && !model.canFinishEditing)
 		}
 		.disabled(!model.isAuthenticated)
 	}
@@ -648,7 +659,7 @@ struct CardView: View {
 							.foregroundStyle(.white.opacity(0.9))
 					}
 					Spacer()
-					Text(model.card.type.rawValue)
+					Text(model.selectedCardType?.rawValue ?? "Card")
 						.font(.caption)
 						.fontWeight(.medium)
 						.foregroundStyle(.white.opacity(0.8))
@@ -775,7 +786,7 @@ struct CardView: View {
 				}
 
 				// Pickers
-				if model.card.type != .otherCard {
+				if model.selectedCardType != .otherCard {
 					Divider()
 					HStack {
 						Text("Network")
@@ -798,9 +809,12 @@ struct CardView: View {
 					Text("Type")
 						.foregroundStyle(.secondary)
 					Spacer()
-					Picker("", selection: $model.card.type) {
+					Picker("", selection: $model.selectedCardType) {
+						if model.isAddNewFlow {
+							Text("Select Card Type").tag(nil as CardType?)
+						}
 						ForEach(CardType.allCases) { type in
-							Text(type.rawValue).tag(type)
+							Text(type.rawValue).tag(type as CardType?)
 						}
 					}
 					.labelsHidden()
@@ -816,7 +830,7 @@ struct CardView: View {
 		.frame(maxWidth: 400)
 
 		// Image section for Other Cards
-		if model.isEditing && model.card.type == .otherCard {
+		if model.isEditing && model.selectedCardType == .otherCard {
 			GroupBox {
 				VStack(spacing: 12) {
 					Button {

--- a/cards/CardView/CardViewModel.swift
+++ b/cards/CardView/CardViewModel.swift
@@ -66,6 +66,13 @@ class CardViewModel: ObservableObject {
 	@Published var isAuthenticated = false
 	@Published var isShowingScanner = false
 	@Published var entryMode: CardEditorEntryMode
+	@Published var selectedCardType: CardType? {
+		didSet {
+			if let selectedCardType {
+				card.type = selectedCardType
+			}
+		}
+	}
 	@Published var lastScanPreview: CardScanResult?
 	@Published var errorMessage: String?
 	@Published var showErrorAlert = false
@@ -86,6 +93,10 @@ class CardViewModel: ObservableObject {
 
 	/// True while a device-owner evaluation is in flight for the current attempt.
 	var isAuthenticating: Bool { activeAuthenticator != nil }
+	var canFinishEditing: Bool {
+		guard let selectedCardType else { return false }
+		return selectedCardType == .otherCard || !card.number.isEmpty
+	}
 
 	init(
 		card: CardData,
@@ -101,7 +112,8 @@ class CardViewModel: ObservableObject {
 		self.isAddNewFlow = addNewFlow
 		self.authenticatorFactory = authenticatorFactory
 		self.sleeper = sleeper
-		self.entryMode = (addNewFlow && card.type != .otherCard) ? .chooser : .form
+		self.entryMode = addNewFlow ? .chooser : .form
+		self.selectedCardType = addNewFlow ? nil : card.type
 		cardImage = ICloudDataManager.shared.loadImage(for: card.id)
 	}
 

--- a/cards/CardView/CardViewModel.swift
+++ b/cards/CardView/CardViewModel.swift
@@ -73,7 +73,6 @@ class CardViewModel: ObservableObject {
 			}
 		}
 	}
-	@Published var lastScanPreview: CardScanResult?
 	@Published var errorMessage: String?
 	@Published var showErrorAlert = false
 	private var scheduledLockTask: Task<Void, Never>?
@@ -221,7 +220,6 @@ class CardViewModel: ObservableObject {
 
 	func applyScan(_ result: CardScanResult) {
 		CardScanSession.apply(result, to: &card)
-		lastScanPreview = result
 		didUseScanner = true
 		entryMode = .form
 		isShowingScanner = false

--- a/cards/Home/HomeView.swift
+++ b/cards/Home/HomeView.swift
@@ -22,100 +22,7 @@ struct HomeView: View {
 	}
 
 	var body: some View {
-		NavigationSplitView {
-			List(selection: $model.selectedCard) {
-				ForEach(CardType.allCases) { type in
-					Section(header: Text("\(type.rawValue)s")){
-						ForEach(model.cardDataStore.cardsByType[type] ?? [], id: \.id) { card in
-							getRowforCards(with: card)
-								.swipeActions(edge: .trailing, allowsFullSwipe: false) {
-									Button(role: .destructive) {
-										deleteCard(card)
-									} label: {
-										Label("Delete", systemImage: "trash")
-									}
-									Button {
-										archiveCard(card)
-									} label: {
-										Label("Archive", systemImage: "archivebox")
-									}
-									.tint(.orange)
-								}
-								.contextMenu {
-									Button {
-										archiveCard(card)
-									} label: {
-										Label("Archive", systemImage: "archivebox")
-									}
-									Button(role: .destructive) {
-										deleteCard(card)
-									} label: {
-										Label("Delete", systemImage: "trash")
-									}
-								}
-						}
-						Button("Add a new \(type.rawValue)") {
-							track(.cardAddStarted)
-							#if os(iOS)
-							addCardSheetDetent = .fraction(0.25)
-							#endif
-							model.addingType = type
-						}
-					}
-				}
-				// Archived Cards Link
-				if !model.cardDataStore.archivedCards.isEmpty {
-					Section {
-						NavigationLink {
-							ArchivedCardsView(model: model)
-						} label: {
-							HStack {
-								Image(systemName: "archivebox")
-								Text("View Archived Cards (\(model.cardDataStore.archivedCards.count))")
-							}
-						}
-					}
-				}
-			}
-			.navigationTitle("Cards")
-			.toolbarTitleDisplayMode(.inlineLarge)
-			.task {
-				model.cardDataStore.loadCards()
-			}
-			#if !os(macOS)
-			.toolbar {
-				ToolbarItem(placement: .topBarTrailing) {
-					NavigationLink(
-						destination: sdk.settingsView()
-							.sdkScreen(AppAnalyticsScreen.settings)
-							.toolbarTitleDisplayMode(.inlineLarge)
-					) {
-						Image(systemName: "gear")
-					}
-				}
-			}
-			#endif
-			.alert("Enable Biometrics",isPresented: model.$isFirstLaunch, actions: {
-				Button("Yes", role: .cancel) { 
-					UserSettings.shared.isAuthEnabled = true
-				}
-				Button("No", role: .destructive) { 
-					UserSettings.shared.isAuthEnabled = false
-				}
-			})
-		} detail: {
-			if let card = model.selectedCard {
-				CardView(model: CardViewModel(
-								card: card,
-								addUpdateCard: { card in
-									model.cardDataStore.addCard(card)
-								}))
-					.id(card.id)
-			} 
-			else {
-				Text("Tap on a Card to view details")
-			}
-		}
+		navigationContent
 		.whatsNewSheet()
 		.onOpenURL { url in
 			model.handleDeepLink(url, onOpenedFromWidget: {
@@ -130,7 +37,7 @@ struct HomeView: View {
 				}))
 			.id(card.id)
 		}
-		.sheet(item: $model.addingType) { type in
+		.sheet(isPresented: $model.isAddingCard) {
 			let cardViewModel = CardViewModel(
 				card: .init(id: UUID(),
 						number: "",
@@ -138,7 +45,7 @@ struct HomeView: View {
 						expiration: "",
 						name: "",
 						description: "",
-						type: type
+						type: .creditCard
 				   ),
 				isEditing: true,
 				addNewFlow: true,
@@ -146,7 +53,7 @@ struct HomeView: View {
 					// Keep the sheet open on failure so the entered form is preserved for retry.
 					let succeeded = model.cardDataStore.addCard(card)
 					if succeeded {
-						model.addingType = nil
+						model.isAddingCard = false
 					}
 					return succeeded
 				}
@@ -172,6 +79,97 @@ struct HomeView: View {
 		.sdkScreen(AppAnalyticsScreen.home)
 	}
 
+	private var navigationContent: some View {
+		NavigationSplitView {
+			sidebar
+		} detail: {
+			selectedCardDetail
+		}
+	}
+
+	private var sidebar: some View {
+		cardList
+			.navigationTitle("Cards")
+			.toolbarTitleDisplayMode(.inlineLarge)
+			.task {
+				model.cardDataStore.loadCards()
+			}
+			.toolbar {
+				ToolbarItem {
+					Button {
+						track(.cardAddStarted)
+						#if os(iOS)
+						addCardSheetDetent = .fraction(0.25)
+						#endif
+						model.isAddingCard = true
+					} label: {
+						Label("Add Card", systemImage: "plus")
+					}
+				}
+				#if !os(macOS)
+				ToolbarItem(placement: .topBarTrailing) {
+					NavigationLink(
+						destination: sdk.settingsView()
+							.sdkScreen(AppAnalyticsScreen.settings)
+							.toolbarTitleDisplayMode(.inlineLarge)
+					) {
+						Image(systemName: "gear")
+					}
+				}
+				#endif
+			}
+			.alert("Enable Biometrics",isPresented: model.$isFirstLaunch, actions: {
+				Button("Yes", role: .cancel) {
+					UserSettings.shared.isAuthEnabled = true
+				}
+				Button("No", role: .destructive) {
+					UserSettings.shared.isAuthEnabled = false
+				}
+			})
+		}
+
+	private var cardList: some View {
+		List(selection: $model.selectedCard) {
+			ForEach(CardType.allCases) { type in
+				cardSection(for: type)
+			}
+			if !model.cardDataStore.archivedCards.isEmpty {
+				Section {
+					NavigationLink {
+						ArchivedCardsView(model: model)
+					} label: {
+						HStack {
+							Image(systemName: "archivebox")
+							Text("View Archived Cards (\(model.cardDataStore.archivedCards.count))")
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private func cardSection(for type: CardType) -> some View {
+		Section(header: Text("\(type.rawValue)s")) {
+			ForEach(model.cardDataStore.cardsByType[type] ?? [], id: \.id) { card in
+				cardRow(withActionsFor: card)
+			}
+		}
+	}
+
+	@ViewBuilder
+	private var selectedCardDetail: some View {
+		if let card = model.selectedCard {
+			CardView(model: CardViewModel(
+				card: card,
+				addUpdateCard: { card in
+					model.cardDataStore.addCard(card)
+				}))
+			.id(card.id)
+		} else {
+			Text("Tap on a Card to view details")
+		}
+	}
+
 	private func deleteCard(_ card: CardData) {
 		let event: AppAnalyticsEvent = model.cardDataStore.deleteCard(with: card.id)
 			? .cardDeleted(location: .active)
@@ -190,6 +188,35 @@ struct HomeView: View {
 		Task {
 			await analytics.capture(event)
 		}
+	}
+
+	private func cardRow(withActionsFor card: CardData) -> some View {
+		getRowforCards(with: card)
+			.swipeActions(edge: .trailing, allowsFullSwipe: false) {
+				Button(role: .destructive) {
+					deleteCard(card)
+				} label: {
+					Label("Delete", systemImage: "trash")
+				}
+				Button {
+					archiveCard(card)
+				} label: {
+					Label("Archive", systemImage: "archivebox")
+				}
+				.tint(.orange)
+			}
+			.contextMenu {
+				Button {
+					archiveCard(card)
+				} label: {
+					Label("Archive", systemImage: "archivebox")
+				}
+				Button(role: .destructive) {
+					deleteCard(card)
+				} label: {
+					Label("Delete", systemImage: "trash")
+				}
+			}
 	}
 
 	private func getRowforCards(with card: CardData) -> some View {

--- a/cards/Home/HomeViewModel.swift
+++ b/cards/Home/HomeViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 class HomeViewModel: ObservableObject {
 
-	@Published var addingType: CardType?
+	@Published var isAddingCard = false
 	@Published var selectedCard: CardData?
 	@Bindable var cardDataStore: CardDataStore
 	@AppStorage("isFirstLaunch") var isFirstLaunch = true

--- a/cards/ScanView/CardCandidateEngine.swift
+++ b/cards/ScanView/CardCandidateEngine.swift
@@ -198,10 +198,14 @@ enum CardholderNameParser {
 		"VISA", "MASTERCARD", "MASTER CARD", "AMEX", "AMERICAN EXPRESS",
 		"DISCOVER", "RUPAY", "UNIONPAY", "UNION PAY", "JCB", "DINERS",
 		"DINERS CLUB", "VALID", "THRU", "GOOD", "FROM", "MONTH", "YEAR",
-		"DEBIT", "CREDIT", "BANK", "CARD", "PLATINUM", "SIGNATURE",
+		"DEBIT", "CREDIT", "BANK", "BANKING", "CARD", "CARDS", "PLATINUM", "SIGNATURE",
 		"WORLD", "ELECTRON", "CLASSIC", "GOLD", "TITANIUM", "BUSINESS",
-		"VALID THRU", "GOOD THRU", "MEMBER SINCE", "CVV", "CVC", "CID"
+		"VALID THRU", "GOOD THRU", "MEMBER SINCE", "CVV", "CVC", "CID",
+		"CUSTOMER", "CARE", "SERVICE", "SERVICES", "HELPLINE", "TOLL", "FREE",
+		"ONLINE", "WEBSITE", "WWW", "COM", "NET", "ORG", "LIMITED", "LTD",
+		"INC", "CORP", "CORPORATION", "LLC", "PLC"
 	]
+	private static let websitePattern = #"(?i)(?:https?://|www(?:\.|\s)|@|\b[a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+)*\.(?:com|net|org|bank|co|in|io|app)\b)"#
 
 	static func parse(from items: [OCRTextItem], panDigits: String?) -> String? {
 		let panDigits = panDigits ?? ""
@@ -224,6 +228,7 @@ enum CardholderNameParser {
 		let compactDigits = CardPAN.digits(in: raw, allowOCRNormalization: false)
 		if compactDigits.count >= 8 { return nil }
 		if CardExpiryParser.parse(raw) != nil { return nil }
+		if raw.range(of: websitePattern, options: .regularExpression) != nil { return nil }
 
 		let letters = raw
 			.replacingOccurrences(of: ",", with: " ")
@@ -239,7 +244,9 @@ enum CardholderNameParser {
 		var cleaned: [String] = []
 		for token in letters {
 			let upper = token.uppercased()
-			if blocked.contains(upper) { continue }
+			if blocked.contains(upper) || upper.hasSuffix("BANK") || upper.hasSuffix("BANKING") {
+				return nil
+			}
 			guard token.count >= 2, token.count <= 20 else { return nil }
 			let allowed = CharacterSet.letters.union(CharacterSet(charactersIn: "'-"))
 			guard token.unicodeScalars.allSatisfy({ allowed.contains($0) }) else {

--- a/cards/ScanView/CardScannerView.swift
+++ b/cards/ScanView/CardScannerView.swift
@@ -39,6 +39,17 @@ struct CardScannerView: View {
 					.padding(.vertical, 8)
 					.background(.black.opacity(0.45), in: Capsule())
 					Spacer()
+					if model.isTorchAvailable {
+						Button {
+							model.toggleTorch()
+						} label: {
+							Image(systemName: model.isTorchOn ? "flashlight.on.fill" : "flashlight.off.fill")
+								.frame(width: 40, height: 40)
+						}
+						.foregroundStyle(model.isTorchOn ? Color.yellow : Color.white)
+						.background(.black.opacity(0.45), in: Circle())
+						.accessibilityLabel(model.isTorchOn ? "Turn flashlight off" : "Turn flashlight on")
+					}
 				}
 				.padding()
 
@@ -86,6 +97,7 @@ final class CardScannerViewModel: ObservableObject {
 	@Published var guidance = "Fit the whole card in the frame"
 	@Published var candidateLastFour: String?
 	@Published var candidateNetwork: CardNetwork?
+	@Published private(set) var isTorchOn = false
 	@Published var showsMessage = false
 	@Published var message = ""
 
@@ -100,6 +112,14 @@ final class CardScannerViewModel: ObservableObject {
 		self.engine = engine ?? CardScanningEngineFactory.make()
 	}
 
+	var isTorchAvailable: Bool {
+		engine.isTorchAvailable
+	}
+
+	func toggleTorch() {
+		isTorchOn = engine.setTorchEnabled(!isTorchOn)
+	}
+
 	func consumeUpdates(
 		onPermissionDenied: @escaping () -> Void,
 		onResult: @escaping (CardScanResult, CardScanMetrics) -> Void
@@ -108,6 +128,7 @@ final class CardScannerViewModel: ObservableObject {
 			guard !stopped else { return }
 			switch update {
 			case .permissionDenied:
+				stop()
 				onPermissionDenied()
 				return
 			case .unsupported(let text), .failed(let text):
@@ -123,7 +144,9 @@ final class CardScannerViewModel: ObservableObject {
 				candidateNetwork = network
 				guidance = "Hold steady…"
 			case .verified(let result):
-				onResult(result, metrics(for: result))
+				let metrics = metrics(for: result)
+				stop()
+				onResult(result, metrics)
 				return
 			}
 		}
@@ -132,6 +155,8 @@ final class CardScannerViewModel: ObservableObject {
 	func stop() {
 		guard !stopped else { return }
 		stopped = true
+		isTorchOn = false
+		engine.setTorchEnabled(false)
 		engine.stop()
 	}
 

--- a/cards/ScanView/CardScanning.swift
+++ b/cards/ScanView/CardScanning.swift
@@ -43,10 +43,19 @@ enum CardScanUpdate: Sendable {
 @MainActor
 protocol CardScanningEngine: AnyObject {
 	var engineID: String { get }
+	var isTorchAvailable: Bool { get }
 	func makeCameraView() -> AnyView
 	func scanUpdates() -> AsyncStream<CardScanUpdate>
 	func verifyCurrentCandidate() async -> CardScanResult?
+	@discardableResult func setTorchEnabled(_ isEnabled: Bool) -> Bool
 	func stop()
+}
+
+extension CardScanningEngine {
+	var isTorchAvailable: Bool { false }
+
+	@discardableResult
+	func setTorchEnabled(_ isEnabled: Bool) -> Bool { false }
 }
 
 enum CardScanningEngineID {

--- a/cards/ScanView/VisionCardScanningEngine.swift
+++ b/cards/ScanView/VisionCardScanningEngine.swift
@@ -21,6 +21,7 @@ final class VisionCardScanningEngine: NSObject, CardScanningEngine {
 	private var isVerifying = false
 	private var didStart = false
 	private var verificationTask: Task<Void, Never>?
+	var isTorchAvailable: Bool { host.isTorchAvailable }
 
 	override init() {
 		super.init()
@@ -51,8 +52,13 @@ final class VisionCardScanningEngine: NSObject, CardScanningEngine {
 		return CardScanSession.result(from: CardFrameObservation(
 			pan: pan,
 			expiry: latestObservation.expiry,
-			cardholderName: latestObservation.cardholderName
+			cardholderName: nil
 		))
+	}
+
+	@discardableResult
+	func setTorchEnabled(_ isEnabled: Bool) -> Bool {
+		host.setTorchEnabled(isEnabled)
 	}
 
 	func stop() {
@@ -95,7 +101,8 @@ final class VisionCardScanningEngine: NSObject, CardScanningEngine {
 		return CardScanResult(
 			pan: livePAN,
 			expiry: still.expiry ?? latestObservation.expiry,
-			cardholderName: still.cardholderName ?? latestObservation.cardholderName,
+			// A missing name is safer than carrying forward a bad live OCR guess.
+			cardholderName: still.cardholderName,
 			network: CardPAN.network(for: livePAN)
 		)
 	}
@@ -222,12 +229,42 @@ private final class VisionScannerHostViewController: UIViewController {
 	}
 
 	func stopScanning() {
+		setTorchEnabled(false)
 		scanner?.stopScanning()
+	}
+
+	var isTorchAvailable: Bool {
+		torchDevice?.hasTorch == true && torchDevice?.isTorchAvailable == true
+	}
+
+	@discardableResult
+	func setTorchEnabled(_ isEnabled: Bool) -> Bool {
+		guard let torchDevice,
+			  torchDevice.hasTorch,
+			  torchDevice.isTorchModeSupported(isEnabled ? .on : .off),
+			  !isEnabled || torchDevice.isTorchAvailable else {
+			return false
+		}
+
+		do {
+			try torchDevice.lockForConfiguration()
+			defer { torchDevice.unlockForConfiguration() }
+			torchDevice.torchMode = isEnabled ? .on : .off
+			return torchDevice.torchMode == (isEnabled ? .on : .off)
+		} catch {
+			return false
+		}
 	}
 
 	func captureStill() async -> UIImage? {
 		return try? await scanner?.capturePhoto()
 	}
+
+	private lazy var torchDevice = AVCaptureDevice.default(
+		.builtInWideAngleCamera,
+		for: .video,
+		position: .back
+	)
 }
 
 extension VisionScannerHostViewController: DataScannerViewControllerDelegate {

--- a/cardsTests/CardScanEngineTests.swift
+++ b/cardsTests/CardScanEngineTests.swift
@@ -170,6 +170,7 @@ final class CardScanSessionTests: XCTestCase {
 			addNewFlow: true,
 			addUpdateCard: { _ in true }
 		)
+		model.selectedCardType = .debitCard
 
 		model.applyScan(
 			CardScanResult(pan: "378282246310005", expiry: nil, cardholderName: nil, network: .amex)
@@ -181,12 +182,14 @@ final class CardScanSessionTests: XCTestCase {
 		XCTAssertEqual(model.card.name, "KEPT NAME")
 		XCTAssertEqual(model.card.cvv, "999")
 		XCTAssertEqual(model.card.description, "Wallet")
+		XCTAssertEqual(model.selectedCardType, .debitCard)
+		XCTAssertEqual(model.card.type, .debitCard)
 		XCTAssertTrue(model.didUseScanner)
 		XCTAssertEqual(model.entryMode, .form)
 		XCTAssertFalse(model.isShowingScanner)
 	}
 
-	func testAddNewPaymentCardStartsOnChooser() {
+	func testAddNewCardStartsOnChooserWithoutSelectedType() {
 		let model = CardViewModel(
 			card: CardData(
 				id: UUID(),
@@ -202,6 +205,40 @@ final class CardScanSessionTests: XCTestCase {
 			addUpdateCard: { _ in true }
 		)
 		XCTAssertEqual(model.entryMode, .chooser)
+		XCTAssertNil(model.selectedCardType)
+		XCTAssertFalse(model.canFinishEditing)
+
+		model.beginManualEntry()
+
+		XCTAssertEqual(model.entryMode, .form)
+		XCTAssertNil(model.selectedCardType)
+	}
+
+	func testScanDoesNotGuessAnUnselectedCardType() {
+		let model = CardViewModel(
+			card: makeBlankCard(),
+			isEditing: true,
+			addNewFlow: true,
+			addUpdateCard: { _ in true }
+		)
+
+		model.applyScan(
+			CardScanResult(
+				pan: "4111111111111111",
+				expiry: "12/30",
+				cardholderName: "JANE DOE",
+				network: .visa
+			)
+		)
+
+		XCTAssertNil(model.selectedCardType)
+		XCTAssertEqual(model.card.network, .visa)
+		XCTAssertFalse(model.canFinishEditing)
+
+		model.selectedCardType = .creditCard
+
+		XCTAssertTrue(model.canFinishEditing)
+		XCTAssertEqual(model.card.type, .creditCard)
 	}
 
 	private func makeBlankCard() -> CardData {

--- a/cardsTests/CardScanEngineTests.swift
+++ b/cardsTests/CardScanEngineTests.swift
@@ -2,6 +2,10 @@ import CoreGraphics
 import XCTest
 @testable import Holder
 
+#if os(iOS)
+import SwiftUI
+#endif
+
 final class CardCandidateEngineTests: XCTestCase {
 	func testReconstructsSplitVisaPAN() {
 		let items = [
@@ -97,6 +101,44 @@ final class CardCandidateEngineTests: XCTestCase {
 		XCTAssertNil(CardholderNameParser.normalizedName("VISA"))
 	}
 
+	func testCardholderNameRejectsIssuerAndWebsiteText() {
+		let rejected = [
+			"www.hdfcbank.com",
+			"HDFC BANK",
+			"STATE BANK OF INDIA",
+			"HDFCBANK COM",
+			"CUSTOMER CARE",
+			"ACME CARD SERVICES"
+		]
+
+		for text in rejected {
+			XCTAssertNil(CardholderNameParser.normalizedName(text), text)
+		}
+	}
+
+	func testCardholderNameKeepsPunctuationUsedInNames() {
+		XCTAssertEqual(CardholderNameParser.normalizedName("ANNE-MARIE O'NEIL"), "ANNE-MARIE O'NEIL")
+	}
+
+	func testObservationPrefersANameOverBankBranding() {
+		let observation = CardCandidateEngine.observe([
+			OCRTextItem(text: "www . hdfc bank . com"),
+			OCRTextItem(text: "STATE BANK OF INDIA"),
+			OCRTextItem(text: "JANE DOE")
+		])
+
+		XCTAssertEqual(observation.cardholderName, "JANE DOE")
+	}
+
+	func testObservationReturnsNoNameForBrandingOnly() {
+		let observation = CardCandidateEngine.observe([
+			OCRTextItem(text: "www.hdfcbank.com"),
+			OCRTextItem(text: "HDFC BANK")
+		])
+
+		XCTAssertNil(observation.cardholderName)
+	}
+
 	func testTemporalVotingRequiresRepeatedPAN() {
 		var voter = TemporalPANVoter(windowSize: 8, requiredVotes: 2)
 		XCTAssertNil(voter.record("4111111111111111"))
@@ -119,6 +161,49 @@ final class CardCandidateEngineTests: XCTestCase {
 		return Calendar(identifier: .gregorian).date(from: components)!
 	}
 }
+
+#if os(iOS)
+@MainActor
+final class CardScannerTorchTests: XCTestCase {
+	func testTorchToggleAndScannerStopTurnTorchOff() {
+		let engine = TorchSpyCardScanningEngine()
+		let model = CardScannerViewModel(isRescan: false, engine: engine)
+
+		XCTAssertTrue(model.isTorchAvailable)
+		XCTAssertFalse(model.isTorchOn)
+
+		model.toggleTorch()
+		XCTAssertTrue(model.isTorchOn)
+		XCTAssertEqual(engine.torchRequests, [true])
+
+		model.stop()
+		XCTAssertFalse(model.isTorchOn)
+		XCTAssertEqual(engine.torchRequests, [true, false])
+		XCTAssertTrue(engine.didStop)
+	}
+}
+
+@MainActor
+private final class TorchSpyCardScanningEngine: CardScanningEngine {
+	let engineID = "torch-spy"
+	let isTorchAvailable = true
+	var torchRequests: [Bool] = []
+	var didStop = false
+
+	func makeCameraView() -> AnyView { AnyView(EmptyView()) }
+	func scanUpdates() -> AsyncStream<CardScanUpdate> { AsyncStream { $0.finish() } }
+	func verifyCurrentCandidate() async -> CardScanResult? { nil }
+
+	func setTorchEnabled(_ isEnabled: Bool) -> Bool {
+		torchRequests.append(isEnabled)
+		return isEnabled
+	}
+
+	func stop() {
+		didStop = true
+	}
+}
+#endif
 
 @MainActor
 final class CardScanSessionTests: XCTestCase {


### PR DESCRIPTION
Closes #54.

Stacked on #45.

## Summary

- replace separate card-type entry points with one Add Card sheet
- choose the card type inside the same sheet before scanning or entering details
- preserve the selected type and entered values through the scan and manual-review flow
- keep validation and saving in the existing CardView boundary
- inherit the privacy-focused on-device scanner and lock handling from #45
- keep the same 25% chooser, 50% scanner, and large manual-review sheet

## Stack

- base: #45 at commit d4c54e0f5b9348edf097021de91e4b6204c4ec92
- head: 2d3ee061f80e8c3bd33078cdbef55f8ec8052590
- the head is one commit ahead of the base and zero commits behind

## Runtime verification

Verified in the real Holder flow on an iPhone 17 Pro simulator:

- Add Card opens the chooser at 25%
- Scan Card transforms that sheet to the 50% camera view
- Cancel returns to the chooser in place
- Enter Manually expands the same sheet
- dismiss and reopen resets to 25%
- no extra screen opens during the complete flow

## Build and TestFlight verification

- exact current generic iOS build: passed locally with Xcode 26.4.1 and code signing disabled
- Swift parse and diff checks: passed
- Xcode Cloud run 210 compiled and exported the exact head for iOS and macOS
- run 210 failed only at Apple's Prepare Build for App Store Connect service step, with no source errors
- signed Holder 2.3 (210) IPA verified with production bundle ID and iOS 17 minimum
- asc committed the build-210 upload, then Apple rejected processing with 90382 because the app reached its daily upload limit
- build 210 is therefore not yet available in TestFlight
- iOS 2.3 build 195 remains valid in Internal TestFlight, but it is the older pre-rebase implementation
- physical iPhone installation was intentionally skipped

## Review

- Cursor Security completed on both current heads with no findings
- Cursor approval routing passed
- CodeRabbit automatic review was skipped because this is a stacked non-default-base PR

## What to test

Once build 210 or a later build of this exact head is available:

1. Open Add Card and choose each supported card type.
2. Confirm Scan Card uses the same lower-half sheet.
3. Confirm Cancel returns to the chooser without another presentation.
4. Confirm manual entry expands the same sheet and saves the selected card type.
5. Confirm locking the app removes the camera and hides scan previews until authentication succeeds.
6. Confirm no external scanner service, API key, or CVV OCR is used.
