### PR TITLE
Use inline large toolbar titles on home screens

### DIFF
--- a/cards/Home/ArchivedCardsView.swift
+++ b/cards/Home/ArchivedCardsView.swift
@@ -52,6 +52,7 @@ struct ArchivedCardsView: View {
 			}
 		}
 		.navigationTitle("Archived Cards")
+		.toolbarTitleDisplayMode(.inlineLarge)
 		.sdkScreen(AppAnalyticsScreen.archivedCards)
 	}
 

--- a/cards/Home/HomeView.swift
+++ b/cards/Home/HomeView.swift
@@ -72,16 +72,20 @@ struct HomeView: View {
 				}
 			}
 			.navigationTitle("Cards")
+			.toolbarTitleDisplayMode(.inlineLarge)
 			.task {
 				model.cardDataStore.loadCards()
 			}
 			#if !os(macOS)
 			.toolbar {
-				NavigationLink(
-					destination: sdk.settingsView()
-						.sdkScreen(AppAnalyticsScreen.settings)
-				) {
-					Image(systemName: "gear")
+				ToolbarItem(placement: .topBarTrailing) {
+					NavigationLink(
+						destination: sdk.settingsView()
+							.sdkScreen(AppAnalyticsScreen.settings)
+							.toolbarTitleDisplayMode(.inlineLarge)
+					) {
+						Image(systemName: "gear")
+					}
 				}
 			}
 			#endif


### PR DESCRIPTION
- Apply inlineLarge title display on Cards, Archived Cards, and Settings
- Place the iOS settings gear in a trailing toolbar item