### PR TITLE
Use the redesign emerald as Holder's accent color

### DIFF
--- a/Widgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Widgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.305882",
+          "green" : "0.364706",
+          "red" : "0.090196"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/cards/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/cards/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.305882",
+          "green" : "0.364706",
+          "red" : "0.090196"
+        }
+      },
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
Holder still falls back to the platform's default accent color, so it does not match the emerald direction from the redesign. This sets the app and widget accent to #175D4E without bringing over any other redesign work.

## Verification

- Confirmed both asset catalogs contain matching universal sRGB values for #175D4E
- Validated both files as JSON with jq
- Ran git diff --check
- Independently reviewed the final diff for correctness and scope
- Xcode build unavailable because this workspace is running on Linux

## Visual evidence

Not captured because this workspace does not provide Xcode or an Apple simulator. This PR changes the shared accent token only.