### PR TITLE
Present Settings as a sheet and use a pencil edit icon

### DIFF
--- a/cards/CardView/CardView.swift
+++ b/cards/CardView/CardView.swift
@@ -360,8 +360,13 @@ struct CardView: View {
 				model.isEditing.toggle()
 				saveCardIfNeeded()
 			}) {
-				Text(model.isEditing ? "Done" : "Edit")
+				if model.isEditing {
+					Text("Done")
+				} else {
+					Image(systemName: "pencil")
+				}
 			}
+			.accessibilityLabel(model.isEditing ? "Done" : "Edit")
 		}
 		.disabled(!$model.isAuthenticated.wrappedValue)
 		#if os(iOS)
@@ -489,8 +494,13 @@ struct CardView: View {
 				model.isEditing.toggle()
 				saveCardIfNeeded()
 			}) {
-				Text(model.isEditing ? "Done" : "Edit")
+				if model.isEditing {
+					Text("Done")
+				} else {
+					Image(systemName: "pencil")
+				}
 			}
+			.accessibilityLabel(model.isEditing ? "Done" : "Edit")
 		}
 		.disabled(!model.isAuthenticated)
 	}

--- a/cards/CardView/CardView.swift
+++ b/cards/CardView/CardView.swift
@@ -356,17 +356,7 @@ struct CardView: View {
 			ShareLink(item: model.card.toShareString()) {
 				Label("Click to share", systemImage: "square.and.arrow.up")
 			}
-			Button(action: {
-				model.isEditing.toggle()
-				saveCardIfNeeded()
-			}) {
-				if model.isEditing {
-					Text("Done")
-				} else {
-					Image(systemName: "pencil")
-				}
-			}
-			.accessibilityLabel(model.isEditing ? "Done" : "Edit")
+			editToolbarButton
 		}
 		.disabled(!$model.isAuthenticated.wrappedValue)
 		#if os(iOS)
@@ -404,6 +394,20 @@ struct CardView: View {
 			}
 		}
 		#endif
+	}
+
+	private var editToolbarButton: some View {
+		Button {
+			model.isEditing.toggle()
+			saveCardIfNeeded()
+		} label: {
+			if model.isEditing {
+				Text("Done")
+			} else {
+				Image(systemName: "pencil")
+			}
+		}
+		.accessibilityLabel(model.isEditing ? "Done" : "Edit")
 	}
 
 	private func saveCardIfNeeded() {
@@ -490,17 +494,7 @@ struct CardView: View {
 			ShareLink(item: model.card.toShareString()) {
 				Label("Share", systemImage: "square.and.arrow.up")
 			}
-			Button(action: {
-				model.isEditing.toggle()
-				saveCardIfNeeded()
-			}) {
-				if model.isEditing {
-					Text("Done")
-				} else {
-					Image(systemName: "pencil")
-				}
-			}
-			.accessibilityLabel(model.isEditing ? "Done" : "Edit")
+			editToolbarButton
 		}
 		.disabled(!model.isAuthenticated)
 	}

--- a/cards/Home/HomeView.swift
+++ b/cards/Home/HomeView.swift
@@ -13,6 +13,9 @@ struct HomeView: View {
 	@ObservedObject var model: HomeViewModel
 	@Environment(\.analytics) private var analytics
 	@Environment(\.sdk) private var sdk
+	#if !os(macOS)
+	@State private var isShowingSettings = false
+	#endif
 
 	init(cardDataStore: CardDataStore = CardDataStore()) {
 		self.model = HomeViewModel(cardDataStore: cardDataStore)
@@ -79,11 +82,9 @@ struct HomeView: View {
 			#if !os(macOS)
 			.toolbar {
 				ToolbarItem(placement: .topBarTrailing) {
-					NavigationLink(
-						destination: sdk.settingsView()
-							.sdkScreen(AppAnalyticsScreen.settings)
-							.toolbarTitleDisplayMode(.inlineLarge)
-					) {
+					Button {
+						isShowingSettings = true
+					} label: {
 						Image(systemName: "gear")
 					}
 				}
@@ -148,6 +149,21 @@ struct HomeView: View {
 				)
 			}
 		}
+		#if !os(macOS)
+		.sheet(isPresented: $isShowingSettings) {
+			NavigationStack {
+				sdk.settingsView()
+					.sdkScreen(AppAnalyticsScreen.settings)
+					.toolbar {
+						ToolbarItem(placement: .confirmationAction) {
+							Button("Done") {
+								isShowingSettings = false
+							}
+						}
+					}
+			}
+		}
+		#endif
 		.sdkScreen(AppAnalyticsScreen.home)
 	}
 


### PR DESCRIPTION
## Summary

- Open Settings as a modal sheet on iOS instead of pushing it onto the home navigation stack
- Keep Settings behind SinghDevKit (`sdk.settingsView()`), including the existing settings analytics screen
- Add a Done button on the sheet so Settings can be dismissed without going back through Home
- Leave macOS Settings unchanged
- Replace the Card View Edit label with a pencil icon, keep Done while editing, and retain Edit/Done accessibility labels

## Testing

- Not run: iOS simulator or device walkthrough of Home, Settings, and Card View
- Not run: macOS build or menu-bar Settings path
- On iOS, tap the Home gear and confirm Settings opens as a sheet rather than a pushed screen
- Confirm the Settings sheet still shows SinghDevKit Settings and can be dismissed with Done
- Confirm dismissing Settings returns to Home without a leftover pushed Settings screen
- On iOS Card View, confirm an unauthenticated session keeps the edit control disabled
- When authenticated, confirm the pencil icon enters edit mode, Done exits it, and VoiceOver still reads Edit and Done
- On macOS, confirm Home and Settings behavior is unchanged