### PR TITLE
Update SinghDevKit integration to 2.6

### DIFF
--- a/cards.xcodeproj/project.pbxproj
+++ b/cards.xcodeproj/project.pbxproj
@@ -1095,7 +1095,7 @@
 			repositoryURL = "https://github.com/swiftlysingh/SinghDevKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.0;
+				minimumVersion = 2.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/cards.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlysingh/SinghDevKit.git",
       "state" : {
-        "revision" : "b1619a17ce1081da0c6f34602d3c1afd0b6b5253",
-        "version" : "2.4.0"
+        "revision" : "88fc9305ef8434f1ea4eb9f7d33f6b4a7d4b4bc5",
+        "version" : "2.6.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Update the SinghDevKit package requirement to 2.6.0.
- Resolve SinghDevKit at version 2.6.0.

## Testing

- Not run (dependency and project configuration update only).